### PR TITLE
Start tracking historic data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Deploy: `npm run build` → `dist/`. GitHub Actions deploys to GitHub Pages.
 
 - **Framework**: SvelteKit 2 + Svelte 5 (runes mode), adapter-static → `dist/`
 - **CSS**: Tailwind CSS v4 via `@tailwindcss/vite`
-- **Charts**: `@observablehq/plot` (log-log scatter of pk vs sig size)
+- **Charts**: Vega-Lite (log-log scatter of pk vs sig size)
 - **Language**: TypeScript throughout
 
 ## Development
@@ -26,53 +26,91 @@ npm run check     # type-check with svelte-check
 
 ## Data
 
-Source of truth is Google Sheets (linked in README). CSV files live in two places:
+Source of truth is `data/schemes/*.yaml` — one YAML file per scheme.
 
-- `data/schemes.csv` and `data/parametersets.csv` — **edit here**
-- `static/data/schemes.csv` and `static/data/parametersets.csv` — **copy from data/ after editing**
+Schema per file:
+```yaml
+name: SchemeName
+website: https://...
+category: Lattice | Multivariate | Hash-based | ...
+assumption: ...
+versions:
+  - version: "FIPS 206"        # human-readable version label
+    date: "2024-08-13"         # ISO date, used to pick latest
+    status: Standardized | On-ramp
+    tags: [round-2]            # round-1, round-2, or omit for reference schemes
+    broken: false              # or string description / "classical"
+    warning: false             # or string description
+    info: false                # or string description
+    parametersets:
+      - name: ML-DSA-44
+        level: 2               # 1-5 or "Pre-Quantum"
+        pk: 1312
+        sig: 2420
+        signing_cycles: 1234567
+        verification_cycles: 234567
+        signing_ms: null       # use cycles OR ms, not both
+        verification_ms: null
+        notes: null
+```
 
-The `data/convert.py` script converts a Numbers-exported semicolon-delimited CSV (`numbers.csv`)
-into the standard `parametersets.csv` — run it from the `data/` directory.
+Security flags (`broken`/`warning`/`info`) can be set at version level (applies to all
+parametersets) or overridden per-parameterset.
 
-Security flags in `schemes.csv`:
-- `Broken` — scheme is broken or classically insecure (value is a description or `"classical"`)
-- `Warning` — known attack weakens the scheme
-- `Info` — informational note about a security concern
+The YAML files are bundled at build time via a Vite plugin (`vite.config.ts`) and
+`import.meta.glob` in `src/lib/schemeData.ts`.
 
 ## Architecture
 
 ```
+data/
+└── schemes/          # one .yaml per scheme (source of truth)
+
 src/
 ├── lib/
-│   ├── types.ts          # Scheme, ParameterSet, FilterState types
+│   ├── types.ts          # Scheme, ParameterSet, SchemeYaml, VersionYaml, FilterState types
 │   ├── constants.ts      # CPUSPEED, NIST_LEVELS
-│   ├── data.ts           # CSV parsing (parseSchemes, parseParameterSets)
+│   ├── data.ts           # processYamlSchemes() — tag-filtered YAML → Scheme[] + ParameterSet[]
 │   ├── filterStore.ts    # Svelte writable store + derived filteredRows + URL codec
+│   ├── roundStore.ts     # writable<'round-1'|'round-2'> — drives dataset selection
+│   ├── schemeData.ts     # import.meta.glob loader → allSchemeData: SchemeYaml[]
 │   ├── themeStore.ts     # dark/light/system theme store → localStorage
-│   ├── plotHelpers.ts    # dotColor, dotSymbol, dotTitle for Observable Plot
+│   ├── yaml.d.ts         # TypeScript module declaration for *.yaml imports
 │   └── components/
-│       ├── SecurityBadge.svelte  # 💣🧨⚠️ℹ️ badges with aria-labels
-│       ├── FilterPanel.svelte    # all filter controls (categories, levels, ranges)
+│       ├── SecurityBadge.svelte  # broken/warning/info badges with aria-labels
+│       ├── FilterPanel.svelte    # filter controls (categories, levels, ranges)
 │       ├── RangeField.svelte     # reusable number input
-│       ├── SchemeTable.svelte    # unified sortable table (one row per parameter set)
-│       └── ScatterPlot.svelte    # Observable Plot wrapper
+│       ├── SchemeTable.svelte    # sortable table (one row per parameter set)
+│       └── ScatterPlot.svelte    # Vega-Lite scatter plot
 └── routes/
-    ├── +layout.svelte    # nav bar (logo, dark toggle), footer
-    ├── +page.ts          # load: fetch CSVs, parse, initialize filter store
-    └── +page.svelte      # page composition, URL state sync in onMount
+    ├── +layout.svelte    # nav (logo, round selector, dark toggle), footer
+    ├── +page.ts          # load: processYamlSchemes('round-2'), createFilterStore
+    └── +page.svelte      # page composition, round switching, URL state sync
 ```
+
+### Data Processing
+
+`processYamlSchemes(allSchemeData, tagFilter?)` in `src/lib/data.ts`:
+- With `tagFilter` (e.g. `'round-2'`): picks the latest version whose `tags` includes that value.
+- Fallback: schemes with no tags on any version are always included (reference schemes like ML-DSA).
+- Schemes that have tags but none matching `tagFilter` are excluded.
 
 ### Filter Store
 
-`src/lib/filterStore.ts` is the core state module. A singleton `writable<FilterState>` is
-initialized by `createFilterStore()` (called from `+page.ts` load function). Components call
-`getFilterStore()` to get the store and `filteredRows` derived store.
+`src/lib/filterStore.ts` uses stable module-level store references. `_store` and `_filteredRows`
+are created once; `createFilterStore()` on subsequent calls (round changes) updates `_allRows`
+and resets `_store` in place. This means components calling `getFilterStore()` at init always
+hold valid references — no stale subscription bugs.
 
-Category checkbox "checked/indeterminate/unchecked" state is **derived** from the scheme set —
-not stored separately. This eliminates the sync-bug class from the old codebase.
+Category checkbox state is **derived** from the scheme set, not stored separately.
 
-URL state: filter params are encoded as query params (see URL codec in `filterStore.ts`).
-Applied client-side in `onMount` (prerender cannot access `url.searchParams`).
+URL state: filter params encoded as query params, applied client-side in `onMount`.
+Round encoded as `?r=1` for round-1 (round-2 is default, no param).
+
+### Round Selector
+
+Nav shows Round 2 / Round 1 toggle (only on home page). Clicking updates `roundStore`, which
+triggers `applyRound()` in `+page.svelte`, which calls `createFilterStore()` with new data.
 
 ### Performance Data
 

--- a/data/schemes/3WISE.yaml
+++ b/data/schemes/3WISE.yaml
@@ -1,0 +1,30 @@
+name: 3WISE
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/3wise-spec-web.pdf
+category: Multivariate
+assumption: cubic degree
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '256'
+    level: 5
+    pk: 2860000
+    sig: 64
+    signing_ms: 0.093
+    verification_ms: 15.33
+  - name: '192'
+    level: 4
+    pk: 918750
+    sig: 48
+    signing_ms: 0.06
+    verification_ms: 5.22
+  - name: '128'
+    level: 2
+    pk: 187000
+    sig: 32
+    signing_ms: 0.038
+    verification_ms: 1.11
+  broken: Broken

--- a/data/schemes/AIMer.yaml
+++ b/data/schemes/AIMer.yaml
@@ -1,0 +1,84 @@
+name: AIMer
+website: https://www.aimer-signature.org/
+category: Symmetric
+assumption: Zero-knowledge proof of knowledge
+versions:
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: L5_PARAM4
+    level: 5
+    pk: 64
+    sig: 15392
+    signing_cycles: 321174411
+    verification_cycles: 310906616
+  - name: L3_PARAM4
+    level: 3
+    pk: 48
+    sig: 8352
+    signing_cycles: 186813161
+    verification_cycles: 177567471
+  - name: L1_PARAM4
+    level: 1
+    pk: 32
+    sig: 3840
+    signing_cycles: 78022625
+    verification_cycles: 73813256
+  - name: L5_PARAM3
+    level: 5
+    pk: 64
+    sig: 17088
+    signing_cycles: 65302783
+    verification_cycles: 62135635
+  - name: L3_PARAM3
+    level: 3
+    pk: 48
+    sig: 9144
+    signing_cycles: 34202905
+    verification_cycles: 33670751
+  - name: L5_PARAM2
+    level: 5
+    pk: 64
+    sig: 19904
+    signing_cycles: 21925850
+    verification_cycles: 21245240
+  - name: L1_PARAM3
+    level: 1
+    pk: 32
+    sig: 4176
+    signing_cycles: 15476644
+    verification_cycles: 15075635
+  - name: L3_PARAM2
+    level: 3
+    pk: 48
+    sig: 10440
+    signing_cycles: 12562067
+    verification_cycles: 12048460
+  - name: L5_PARAM1
+    level: 5
+    pk: 64
+    sig: 25152
+    signing_cycles: 8573223
+    verification_cycles: 8181552
+  - name: L3_PARAM1
+    level: 3
+    pk: 48
+    sig: 13080
+    signing_cycles: 4838748
+    verification_cycles: 4494766
+  - name: L1_PARAM2
+    level: 1
+    pk: 32
+    sig: 4880
+    signing_cycles: 4747229
+    verification_cycles: 4474325
+  - name: L1_PARAM1
+    level: 1
+    pk: 32
+    sig: 5904
+    signing_cycles: 2079167
+    verification_cycles: 1840810
+  warning: Original AIM cipher was insecure

--- a/data/schemes/ALTEQ.yaml
+++ b/data/schemes/ALTEQ.yaml
@@ -1,0 +1,48 @@
+name: ALTEQ
+website: https://pqcalteq.github.io/
+category: Other
+assumption: alternating trilinear form equivalence problem
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: Balanced-V
+    level: 5
+    pk: 73632
+    sig: 122336
+    signing_cycles: 59708622
+    verification_cycles: 103463869
+  - name: Balanced-III
+    level: 3
+    pk: 31944
+    sig: 49000
+    signing_cycles: 36460660
+    verification_cycles: 46054633
+  - name: ShortSig-V
+    level: 5
+    pk: 2088432
+    sig: 63908
+    signing_cycles: 30558103
+    verification_cycles: 50354691
+  - name: ShortSig-III
+    level: 3
+    pk: 1044264
+    sig: 32504
+    signing_cycles: 7815599
+    verification_cycles: 14609046
+  - name: Balanced-I
+    level: 1
+    pk: 8024
+    sig: 15896
+    signing_cycles: 2847138
+    verification_cycles: 4226834
+  - name: ShortSig-I
+    level: 1
+    pk: 523968
+    sig: 9528
+    signing_cycles: 725973
+    verification_cycles: 1766808
+  info: 1/q chance at generating weak keys

--- a/data/schemes/Ascon-Sign.yaml
+++ b/data/schemes/Ascon-Sign.yaml
@@ -1,0 +1,59 @@
+name: Ascon-Sign
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/Ascon-sign-spec-web.pdf
+category: Symmetric
+assumption: SPHINCS+ with Ascon
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 192s robust
+    level: 3
+    pk: 48
+    sig: 16224
+    signing_cycles: 8893090510
+    verification_cycles: 7664451
+  - name: 192s simple
+    level: 3
+    pk: 48
+    sig: 16224
+    signing_cycles: 5046224790
+    verification_cycles: 4357430
+  - name: 128s robust
+    level: 1
+    pk: 32
+    sig: 7856
+    signing_cycles: 4038032800
+    verification_cycles: 4232362
+  - name: 128s simple
+    level: 1
+    pk: 32
+    sig: 7856
+    signing_cycles: 2224377542
+    verification_cycles: 2137821
+  - name: 192f robust
+    level: 3
+    pk: 48
+    sig: 35664
+    signing_cycles: 381735599
+    verification_cycles: 21408883
+  - name: 192f simple
+    level: 3
+    pk: 48
+    sig: 35664
+    signing_cycles: 226197880
+    verification_cycles: 12333664
+  - name: 128f robust
+    level: 1
+    pk: 32
+    sig: 17088
+    signing_cycles: 182601975
+    verification_cycles: 11279318
+  - name: 128f simple
+    level: 1
+    pk: 32
+    sig: 17088
+    signing_cycles: 107020221
+    verification_cycles: 6535295

--- a/data/schemes/Biscuit.yaml
+++ b/data/schemes/Biscuit.yaml
@@ -1,0 +1,48 @@
+name: Biscuit
+website: https://www.biscuit-pqc.org/
+category: Multivariate
+assumption: 'multivariate: solving generic structured algebraic equations'
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256s
+    level: 5
+    pk: 93
+    sig: 20192
+    signing_cycles: 1291111734
+    verification_cycles: 1274568395
+  - name: 192s
+    level: 3
+    pk: 69
+    sig: 11349
+    signing_cycles: 724466241
+    verification_cycles: 714947231
+  - name: 256f
+    level: 5
+    pk: 93
+    sig: 27348
+    signing_cycles: 147099575
+    verification_cycles: 137359832
+  - name: 192f
+    level: 3
+    pk: 69
+    sig: 15129
+    signing_cycles: 81492308
+    verification_cycles: 75826788
+  - name: 128s
+    level: 1
+    pk: 50
+    sig: 4758
+    signing_cycles: 80555671
+    verification_cycles: 78899797
+  - name: 128f
+    level: 1
+    pk: 50
+    sig: 6726
+    signing_cycles: 9653412
+    verification_cycles: 8734302
+  warning: smaller security margin

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -117,3 +117,81 @@ versions:
     verification_cycles: 422000
   tags:
   - round-2
+- version: Round 1
+  date: '2023-06-02'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: R-SDP 5 small
+    level: 5
+    pk: 121
+    sig: 43373
+    signing_cycles: 74830000
+    verification_cycles: 26130000
+  - name: R-SDP 3 small
+    level: 3
+    pk: 91
+    sig: 23407
+    signing_cycles: 46490000
+    verification_cycles: 18340000
+  - name: R-SDP 5 fast
+    level: 5
+    pk: 121
+    sig: 51120
+    signing_cycles: 37090000
+    verification_cycles: 14560000
+  - name: R-SDP(G) 5 small
+    level: 5
+    pk: 77
+    sig: 31696
+    signing_cycles: 29080000
+    verification_cycles: 19440000
+  - name: R-SDP 1 small
+    level: 1
+    pk: 61
+    sig: 10304
+    signing_cycles: 22000000
+    verification_cycles: 10280000
+  - name: R-SDP(G) 3 small
+    level: 3
+    pk: 56
+    sig: 17429
+    signing_cycles: 18060000
+    verification_cycles: 12240000
+  - name: R-SDP 3 fast
+    level: 3
+    pk: 91
+    sig: 37080
+    signing_cycles: 11810000
+    verification_cycles: 5870000
+  - name: R-SDP(G) 5 fast
+    level: 5
+    pk: 77
+    sig: 37924
+    signing_cycles: 11050000
+    verification_cycles: 7490000
+  - name: R-SDP(G) 1 small
+    level: 1
+    pk: 38
+    sig: 7625
+    signing_cycles: 11040000
+    verification_cycles: 7490000
+  - name: R-SDP 1 fast
+    level: 1
+    pk: 61
+    sig: 12944
+    signing_cycles: 6700000
+    verification_cycles: 3170000
+  - name: R-SDP(G) 3 fast
+    level: 3
+    pk: 56
+    sig: 21697
+    signing_cycles: 4910000
+    verification_cycles: 3230000
+  - name: R-SDP(G) 1 fast
+    level: 1
+    pk: 38
+    sig: 8665
+    signing_cycles: 3080000
+    verification_cycles: 2110000

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -3,8 +3,8 @@ website: https://cross-crypto.com/
 category: Code-based
 assumption: Restricted syndrome decoding
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2
+  date: '2025-01-31'
   status: On-ramp
   parametersets:
   - name: R-SDP 5 small
@@ -115,3 +115,5 @@ versions:
     sig: 11980
     signing_cycles: 687000
     verification_cycles: 422000
+tags:
+- round-2

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -29,7 +29,7 @@ versions:
     level: 3
     pk: 115
     sig: 29853
-    signing_cycles: 4161000
+    signing_cycles: 4171000
     verification_cycles: 2776000
   - name: R-SDP 5 fast
     level: 5
@@ -52,7 +52,7 @@ versions:
   - name: R-SDP 1 small
     level: 1
     pk: 77
-    sig: 12434
+    sig: 12432
     signing_cycles: 4048000
     verification_cycles: 2725000
   - name: R-SDP 1 balanced

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -115,5 +115,7 @@ versions:
     sig: 11980
     signing_cycles: 687000
     verification_cycles: 422000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -117,5 +117,3 @@ versions:
     verification_cycles: 422000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/CROSS.yaml
+++ b/data/schemes/CROSS.yaml
@@ -1,0 +1,117 @@
+name: CROSS
+website: https://cross-crypto.com/
+category: Code-based
+assumption: Restricted syndrome decoding
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: R-SDP 5 small
+    level: 5
+    pk: 153
+    sig: 50818
+    signing_cycles: 11356000
+    verification_cycles: 7765000
+  - name: R-SDP 5 balanced
+    level: 5
+    pk: 153
+    sig: 53527
+    signing_cycles: 7042000
+    verification_cycles: 4752000
+  - name: R-SDP 3 small
+    level: 3
+    pk: 115
+    sig: 28391
+    signing_cycles: 6254000
+    verification_cycles: 4277000
+  - name: R-SDP 3 balanced
+    level: 3
+    pk: 115
+    sig: 29853
+    signing_cycles: 4161000
+    verification_cycles: 2776000
+  - name: R-SDP 5 fast
+    level: 5
+    pk: 153
+    sig: 74590
+    signing_cycles: 4116000
+    verification_cycles: 2512000
+  - name: R-SDP(G) 5 small
+    level: 5
+    pk: 106
+    sig: 36454
+    signing_cycles: 6197000
+    verification_cycles: 4059000
+  - name: R-SDP(G) 5 balanced
+    level: 5
+    pk: 106
+    sig: 40100
+    signing_cycles: 3482000
+    verification_cycles: 2248000
+  - name: R-SDP 1 small
+    level: 1
+    pk: 77
+    sig: 12434
+    signing_cycles: 4048000
+    verification_cycles: 2725000
+  - name: R-SDP 1 balanced
+    level: 1
+    pk: 77
+    sig: 13152
+    signing_cycles: 2013000
+    verification_cycles: 1270000
+  - name: R-SDP(G) 3 small
+    level: 3
+    pk: 83
+    sig: 20452
+    signing_cycles: 4195000
+    verification_cycles: 2832000
+  - name: R-SDP(G) 3 balanced
+    level: 3
+    pk: 83
+    sig: 22464
+    signing_cycles: 2240000
+    verification_cycles: 1446000
+  - name: R-SDP 3 fast
+    level: 3
+    pk: 115
+    sig: 41406
+    signing_cycles: 2324000
+    verification_cycles: 1398000
+  - name: R-SDP(G) 5 fast
+    level: 5
+    pk: 106
+    sig: 48102
+    signing_cycles: 2580000
+    verification_cycles: 1634000
+  - name: R-SDP(G) 1 small
+    level: 1
+    pk: 54
+    sig: 8960
+    signing_cycles: 3137000
+    verification_cycles: 1971000
+  - name: R-SDP(G) 1 balanced
+    level: 1
+    pk: 54
+    sig: 9120
+    signing_cycles: 1579000
+    verification_cycles: 985000
+  - name: R-SDP 1 fast
+    level: 1
+    pk: 77
+    sig: 18432
+    signing_cycles: 1007000
+    verification_cycles: 572000
+  - name: R-SDP(G) 3 fast
+    level: 3
+    pk: 83
+    sig: 26772
+    signing_cycles: 1555000
+    verification_cycles: 982000
+  - name: R-SDP(G) 1 fast
+    level: 1
+    pk: 54
+    sig: 11980
+    signing_cycles: 687000
+    verification_cycles: 422000

--- a/data/schemes/DME-Sign.yaml
+++ b/data/schemes/DME-Sign.yaml
@@ -1,0 +1,30 @@
+name: DME-Sign
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/DME_SIGN-spec-web.pdf
+category: Multivariate
+assumption: deterministic trapdoor permutation
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 2^64
+    level: 5
+    pk: 2889
+    sig: 64
+    signing_ms: 0.04
+    verification_ms: 0.01
+  - name: 2^48
+    level: 3
+    pk: 2169
+    sig: 48
+    signing_ms: 0.04
+    verification_ms: 0.01
+  - name: 2^32
+    level: 1
+    pk: 1449
+    sig: 32
+    signing_ms: 0.02
+    verification_ms: 0.01
+  broken: 2^96 signature forgery

--- a/data/schemes/EHTv3_EHTv4.yaml
+++ b/data/schemes/EHTv3_EHTv4.yaml
@@ -1,0 +1,42 @@
+name: EHTv3 / EHTv4
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/EHTv3v4-spec-web.pdf
+category: Lattices
+assumption: Lattices?
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: v3-5
+    level: 5
+    pk: 349000
+    sig: 344
+    signing_ms: 305.0
+    verification_ms: 3.16
+  - name: v3-3
+    level: 3
+    pk: 191600
+    sig: 255
+    signing_ms: 206.0
+    verification_ms: 1.78
+  - name: v3-1
+    level: 1
+    pk: 83500
+    sig: 169
+    signing_ms: 75.8
+    verification_ms: 0.82
+  - name: v4-5
+    level: 5
+    pk: 2630
+    sig: 857
+    signing_ms: 59.3
+    verification_ms: 26.2
+  - name: v4-1
+    level: 1
+    pk: 1110
+    sig: 369
+    signing_ms: 9.0
+    verification_ms: 3.85
+  broken: EHTv3 is broken

--- a/data/schemes/EagleSign.yaml
+++ b/data/schemes/EagleSign.yaml
@@ -1,0 +1,32 @@
+name: EagleSign
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/EagleSign-spec-web.pdf
+category: Lattices
+assumption: MNTRU/MLWE
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: Recomm I
+    level: 3
+    pk: 1824
+    sig: 2336
+    signing_cycles: 1286413
+    verification_cycles: 2251036
+  - name: High I
+    level: 5
+    pk: 3616
+    sig: 3488
+    signing_cycles: 917213
+    verification_cycles: 1503004
+  - name: Recomm II
+    level: 3
+    pk: 3616
+    sig: 2464
+  - name: Medium
+    level: 2
+    pk: 1824
+    sig: 2144
+  broken: signature leaks secret key

--- a/data/schemes/EdDSA.yaml
+++ b/data/schemes/EdDSA.yaml
@@ -1,0 +1,16 @@
+name: EdDSA
+website: https://ed25519.cr.yp.to/
+category: Pre-Quantum
+assumption: Elliptic Curves
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: Classic cryptography
+  parametersets:
+  - name: Ed25519
+    level: Pre-Quantum
+    pk: 32
+    sig: 64
+    signing_cycles: 42000
+    verification_cycles: 130000
+  broken: classical

--- a/data/schemes/Enhanced_pqsigRM.yaml
+++ b/data/schemes/Enhanced_pqsigRM.yaml
@@ -1,0 +1,18 @@
+name: Enhanced pqsigRM
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/Enhanced-pqsigRM-spec-web.pdf
+category: Code-based
+assumption: Reed Muller codes
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '128'
+    level: 1
+    pk: 2000000
+    sig: 1032
+    signing_cycles: 1366500
+    verification_cycles: 242901
+  broken: signatures leak secret information

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -81,3 +81,81 @@ versions:
     verification_cycles: 1113000
   tags:
   - round-2
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 192s
+    level: 3
+    pk: 64
+    sig: 12744
+    signing_ms: 19.18
+    verification_ms: 19.31
+  - name: 192f
+    level: 3
+    pk: 64
+    sig: 16792
+    signing_ms: 1.96
+    verification_ms: 1.96
+  - name: 256s
+    level: 5
+    pk: 64
+    sig: 22100
+    signing_ms: 26.65
+    verification_ms: 26.76
+  - name: 256f
+    level: 5
+    pk: 64
+    sig: 28400
+    signing_ms: 3.1
+    verification_ms: 3.1
+  - name: EM-256s
+    level: 5
+    pk: 64
+    sig: 20956
+    signing_ms: 25.65
+    verification_ms: 25.87
+  - name: EM-256f
+    level: 5
+    pk: 64
+    sig: 26736
+    signing_ms: 3.04
+    verification_ms: 3.03
+  - name: EM-192s
+    level: 3
+    pk: 48
+    sig: 10824
+    signing_ms: 18.46
+    verification_ms: 18.52
+  - name: EM-192f
+    level: 3
+    pk: 48
+    sig: 13912
+    signing_ms: 1.87
+    verification_ms: 1.87
+  - name: 128s
+    level: 1
+    pk: 32
+    sig: 5006
+    signing_ms: 8.1
+    verification_ms: 8.1
+  - name: 128f
+    level: 1
+    pk: 32
+    sig: 6336
+    signing_ms: 0.87
+    verification_ms: 0.87
+  - name: EM-128s
+    level: 1
+    pk: 32
+    sig: 4566
+    signing_ms: 8.09
+    verification_ms: 8.05
+  - name: EM-128f
+    level: 1
+    pk: 32
+    sig: 5696
+    signing_ms: 0.85
+    verification_ms: 0.86

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -9,25 +9,25 @@ versions:
   parametersets:
   - name: 192s
     level: 3
-    pk: 64
+    pk: 48
     sig: 11260
     signing_cycles: 54687000
     verification_cycles: 42290000
   - name: 192f
     level: 3
-    pk: 64
+    pk: 48
     sig: 14948
     signing_cycles: 7045000
     verification_cycles: 6079000
   - name: 256s
     level: 5
-    pk: 64
+    pk: 48
     sig: 20696
     signing_cycles: 76330000
     verification_cycles: 74546000
   - name: 256f
     level: 5
-    pk: 64
+    pk: 48
     sig: 26548
     signing_cycles: 11071000
     verification_cycles: 10241000
@@ -53,7 +53,7 @@ versions:
     level: 3
     pk: 48
     sig: 12380
-    signing_cycles: 5117000
+    signing_cycles: 5177000
     verification_cycles: 4665000
   - name: 128s
     level: 1

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -1,0 +1,81 @@
+name: FAEST
+website: https://faest.info
+category: Symmetric
+assumption: symmetric / zero-knowledge VOLE-in-the-Head
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: 192s
+    level: 3
+    pk: 64
+    sig: 11260
+    signing_cycles: 54687000
+    verification_cycles: 42290000
+  - name: 192f
+    level: 3
+    pk: 64
+    sig: 14948
+    signing_cycles: 7045000
+    verification_cycles: 6079000
+  - name: 256s
+    level: 5
+    pk: 64
+    sig: 20696
+    signing_cycles: 76330000
+    verification_cycles: 74546000
+  - name: 256f
+    level: 5
+    pk: 64
+    sig: 26548
+    signing_cycles: 11071000
+    verification_cycles: 10241000
+  - name: EM-256s
+    level: 5
+    pk: 64
+    sig: 17984
+    signing_cycles: 62465000
+    verification_cycles: 59738000
+  - name: EM-256f
+    level: 5
+    pk: 64
+    sig: 23476
+    signing_cycles: 9436000
+    verification_cycles: 8725000
+  - name: EM-192s
+    level: 3
+    pk: 48
+    sig: 9340
+    signing_cycles: 39282000
+    verification_cycles: 36239000
+  - name: EM-192f
+    level: 3
+    pk: 48
+    sig: 12380
+    signing_cycles: 5117000
+    verification_cycles: 4665000
+  - name: 128s
+    level: 1
+    pk: 32
+    sig: 4506
+    signing_cycles: 12787000
+    verification_cycles: 9783000
+  - name: 128f
+    level: 1
+    pk: 32
+    sig: 5924
+    signing_cycles: 1722000
+    verification_cycles: 1413000
+  - name: EM-128s
+    level: 1
+    pk: 32
+    sig: 3906
+    signing_cycles: 9403000
+    verification_cycles: 7398000
+  - name: EM-128f
+    level: 1
+    pk: 32
+    sig: 5060
+    signing_cycles: 1404000
+    verification_cycles: 1113000

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -81,5 +81,3 @@ versions:
     verification_cycles: 1113000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -3,8 +3,8 @@ website: https://faest.info
 category: Symmetric
 assumption: symmetric / zero-knowledge VOLE-in-the-Head
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-07'
   status: On-ramp
   parametersets:
   - name: 192s
@@ -79,3 +79,5 @@ versions:
     sig: 5060
     signing_cycles: 1404000
     verification_cycles: 1113000
+tags:
+- round-2

--- a/data/schemes/FAEST.yaml
+++ b/data/schemes/FAEST.yaml
@@ -79,5 +79,7 @@ versions:
     sig: 5060
     signing_cycles: 1404000
     verification_cycles: 1113000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/Falcon.yaml
+++ b/data/schemes/Falcon.yaml
@@ -1,0 +1,21 @@
+name: Falcon
+website: https://falcon-sign.info
+category: Lattices
+assumption: NTRU-SIS
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: To be standardized
+  parametersets:
+  - name: '1024'
+    level: 5
+    pk: 1793
+    sig: 1280
+    signing_cycles: 2053080
+    verification_cycles: 160596
+  - name: '512'
+    level: 1
+    pk: 897
+    sig: 666
+    signing_cycles: 1009764
+    verification_cycles: 81036

--- a/data/schemes/FuLeeca.yaml
+++ b/data/schemes/FuLeeca.yaml
@@ -1,0 +1,30 @@
+name: FuLeeca
+website: https://www.ce.cit.tum.de/lnt/forschung/professur-fuer-coding-and-cryptography/fuleeca/
+category: Code-based
+assumption: Code-based Lee Metric
+versions:
+- version: Round 1
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V
+    level: 5
+    pk: 2638
+    sig: 2130
+    signing_cycles: 12327726000
+    verification_cycles: 3789000
+  - name: III
+    level: 3
+    pk: 1982
+    sig: 1620
+    signing_cycles: 2111156000
+    verification_cycles: 2447000
+  - name: I
+    level: 1
+    pk: 1318
+    sig: 1100
+    signing_cycles: 1846779000
+    verification_cycles: 1260000
+  broken: Private key recovery

--- a/data/schemes/HAETAE.yaml
+++ b/data/schemes/HAETAE.yaml
@@ -1,0 +1,30 @@
+name: HAETAE
+website: https://kpqc.cryptolab.co.kr/haetae
+category: Lattices
+assumption: MLWE/MSIS
+versions:
+- version: Round 1
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '180'
+    level: 3
+    pk: 1472
+    sig: 2337
+    signing_cycles: 9472724
+    verification_cycles: 718010
+  - name: '260'
+    level: 5
+    pk: 2080
+    sig: 2908
+    signing_cycles: 8989980
+    verification_cycles: 913378
+  - name: '120'
+    level: 2
+    pk: 992
+    sig: 1463
+    signing_cycles: 6253166
+    verification_cycles: 387594
+  info: Original version has bit-flipping signature forgery

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -21,5 +21,3 @@ versions:
     verification_cycles: 148224
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -21,3 +21,21 @@ versions:
     verification_cycles: 148224
   tags:
   - round-2
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '1024'
+    level: 5
+    pk: 2440
+    sig: 1221
+    signing_cycles: 180816
+    verification_cycles: 302861
+  - name: '512'
+    level: 1
+    pk: 1024
+    sig: 555
+    signing_cycles: 85372
+    verification_cycles: 148224

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -3,8 +3,8 @@ website: https://hawk-sign.info
 category: Lattices
 assumption: Lattice Isomorphism Problem
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v1.1
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: '1024'
@@ -19,3 +19,5 @@ versions:
     sig: 555
     signing_cycles: 85372
     verification_cycles: 148224
+tags:
+- round-2

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -1,0 +1,21 @@
+name: HAWK
+website: https://hawk-sign.info
+category: Lattices
+assumption: Lattice Isomorphism Problem
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: '1024'
+    level: 5
+    pk: 2440
+    sig: 1221
+    signing_cycles: 180816
+    verification_cycles: 302861
+  - name: '512'
+    level: 1
+    pk: 1024
+    sig: 555
+    signing_cycles: 85372
+    verification_cycles: 148224

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -19,5 +19,7 @@ versions:
     sig: 555
     signing_cycles: 85372
     verification_cycles: 148224
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/HPPC.yaml
+++ b/data/schemes/HPPC.yaml
@@ -1,0 +1,30 @@
+name: HPPC
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/hppc-spec-web.pdf
+category: Multivariate
+assumption: HFE
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '256'
+    level: 5
+    pk: 1028000
+    sig: 33
+    signing_ms: 1200.0
+    verification_ms: 25.1
+  - name: '192'
+    level: 4
+    pk: 434250
+    sig: 25
+    signing_ms: 1000.0
+    verification_ms: 10.7
+  - name: '128'
+    level: 2
+    pk: 129000
+    sig: 21
+    signing_ms: 689.75
+    verification_ms: 3.18
+  broken: 2^64 collision / universal forgery attack

--- a/data/schemes/HuFu.yaml
+++ b/data/schemes/HuFu.yaml
@@ -1,0 +1,48 @@
+name: HuFu
+website: http://123.56.244.4/
+category: Lattices
+assumption: LWE/SIS
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: NIST-5 SHAKE
+    level: 5
+    pk: 3573000
+    sig: 4520
+    signing_cycles: 21849000
+    verification_cycles: 13697000
+  - name: NIST-3 SHAKE
+    level: 3
+    pk: 2177000
+    sig: 3540
+    signing_cycles: 13022000
+    verification_cycles: 8510000
+  - name: NIST-5 AES
+    level: 5
+    pk: 3573000
+    sig: 4520
+    signing_cycles: 12091000
+    verification_cycles: 3811000
+  - name: NIST-3 AES
+    level: 3
+    pk: 2177000
+    sig: 3540
+    signing_cycles: 7001000
+    verification_cycles: 2358000
+  - name: NIST-1 SHAKE
+    level: 1
+    pk: 1059000
+    sig: 2455
+    signing_cycles: 6342000
+    verification_cycles: 3069000
+  - name: NIST-1 AES
+    level: 1
+    pk: 1059000
+    sig: 2455
+    signing_cycles: 3872000
+    verification_cycles: 801000
+  info: Original version had bit-flipping signature forgery

--- a/data/schemes/KAZ-Sign.yaml
+++ b/data/schemes/KAZ-Sign.yaml
@@ -1,0 +1,30 @@
+name: KAZ-Sign
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/kaz-sign-spec-web.pdf
+category: Other
+assumption: Second-order Discrete Logarithm Problem
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: KAZ970
+    level: 5
+    pk: 243
+    sig: 153
+    signing_ms: 43319.0
+    verification_ms: 22650.0
+  - name: KAZ738
+    level: 3
+    pk: 185
+    sig: 117
+    signing_ms: 20822.0
+    verification_ms: 10306.0
+  - name: KAZ458
+    level: 1
+    pk: 115
+    sig: 74
+    signing_ms: 9955.0
+    verification_ms: 2696.0
+  broken: universal signature forgery

--- a/data/schemes/LESS.yaml
+++ b/data/schemes/LESS.yaml
@@ -49,5 +49,7 @@ versions:
     sig: 7436
     signing_cycles: 560000000
     verification_cycles: 564600000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/LESS.yaml
+++ b/data/schemes/LESS.yaml
@@ -51,5 +51,3 @@ versions:
     verification_cycles: 564600000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/LESS.yaml
+++ b/data/schemes/LESS.yaml
@@ -51,3 +51,52 @@ versions:
     verification_cycles: 564600000
   tags:
   - round-2
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 5b
+    level: 5
+    pk: 66151
+    sig: 33280
+    signing_cycles: 10212600000
+    verification_cycles: 10458800000
+  - name: 5s
+    level: 5
+    pk: 132096
+    sig: 26727
+    signing_cycles: 6763200000
+    verification_cycles: 7016500000
+  - name: 3s
+    level: 3
+    pk: 70554
+    sig: 14439
+    signing_cycles: 2984300000
+    verification_cycles: 3075100000
+  - name: 3b
+    level: 3
+    pk: 35328
+    sig: 18842
+    signing_cycles: 2446900000
+    verification_cycles: 2521400000
+  - name: 1b
+    level: 1
+    pk: 14029
+    sig: 8602
+    signing_cycles: 263600000
+    verification_cycles: 271400000
+  - name: 1i
+    level: 1
+    pk: 42087
+    sig: 6247
+    signing_cycles: 254300000
+    verification_cycles: 263400000
+  - name: 1s
+    level: 1
+    pk: 98202
+    sig: 5325
+    signing_cycles: 206600000
+    verification_cycles: 213400000
+  info: Original specification lacks verification of well-formed matrices

--- a/data/schemes/LESS.yaml
+++ b/data/schemes/LESS.yaml
@@ -3,8 +3,8 @@ website: https://less-project.com
 category: Code-based
 assumption: Linear Equivalence Problem
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-07'
   status: On-ramp
   parametersets:
   - name: 252-192
@@ -49,3 +49,5 @@ versions:
     sig: 7436
     signing_cycles: 560000000
     verification_cycles: 564600000
+tags:
+- round-2

--- a/data/schemes/LESS.yaml
+++ b/data/schemes/LESS.yaml
@@ -1,0 +1,51 @@
+name: LESS
+website: https://less-project.com
+category: Code-based
+assumption: Linear Equivalence Problem
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: 252-192
+    level: 1
+    pk: 13940
+    sig: 2625
+    signing_cycles: 127500000
+    verification_cycles: 122700000
+  - name: 252-68
+    level: 1
+    pk: 41788
+    sig: 1825
+    signing_cycles: 45900000
+    verification_cycles: 44800000
+  - name: 252-45
+    level: 1
+    pk: 97484
+    sig: 1329
+    signing_cycles: 30600000
+    verification_cycles: 30000000
+  - name: 400-220
+    level: 3
+    pk: 35074
+    sig: 6329
+    signing_cycles: 401500000
+    verification_cycles: 392700000
+  - name: 400-102
+    level: 3
+    pk: 105174
+    sig: 4131
+    signing_cycles: 184000000
+    verification_cycles: 181300000
+  - name: 548-345
+    level: 5
+    pk: 65793
+    sig: 10680
+    signing_cycles: 1424200000
+    verification_cycles: 1396000000
+  - name: 548-137
+    level: 5
+    pk: 197315
+    sig: 7436
+    signing_cycles: 560000000
+    verification_cycles: 564600000

--- a/data/schemes/MAYO.yaml
+++ b/data/schemes/MAYO.yaml
@@ -34,5 +34,3 @@ versions:
   warning: There is an attack on a parameterset with a specific structure
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/MAYO.yaml
+++ b/data/schemes/MAYO.yaml
@@ -34,3 +34,33 @@ versions:
   warning: There is an attack on a parameterset with a specific structure
   tags:
   - round-2
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: five
+    level: 5
+    pk: 5008
+    sig: 838
+    signing_cycles: 4149954
+    verification_cycles: 1186132
+  - name: three
+    level: 3
+    pk: 2656
+    sig: 577
+    signing_cycles: 1663666
+    verification_cycles: 610010
+  - name: two
+    level: 1
+    pk: 5488
+    sig: 180
+    signing_cycles: 563900
+    verification_cycles: 91512
+  - name: one
+    level: 1
+    pk: 1168
+    sig: 321
+    signing_cycles: 460978
+    verification_cycles: 175158

--- a/data/schemes/MAYO.yaml
+++ b/data/schemes/MAYO.yaml
@@ -1,0 +1,34 @@
+name: MAYO
+website: https://pqmayo.org
+category: Multivariate
+assumption: Multivariate quadratic
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: five
+    level: 5
+    pk: 5554
+    sig: 964
+    signing_cycles: 2387350
+    verification_cycles: 853920
+  - name: three
+    level: 3
+    pk: 2986
+    sig: 681
+    signing_cycles: 1017216
+    verification_cycles: 347972
+  - name: two
+    level: 1
+    pk: 4912
+    sig: 186
+    signing_cycles: 286028
+    verification_cycles: 56374
+  - name: one
+    level: 1
+    pk: 1420
+    sig: 454
+    signing_cycles: 471028
+    verification_cycles: 153266
+  warning: There is an attack on a parameterset with a specific structure

--- a/data/schemes/MAYO.yaml
+++ b/data/schemes/MAYO.yaml
@@ -3,8 +3,8 @@ website: https://pqmayo.org
 category: Multivariate
 assumption: Multivariate quadratic
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: Round 2
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: five
@@ -32,3 +32,5 @@ versions:
     signing_cycles: 471028
     verification_cycles: 153266
   warning: There is an attack on a parameterset with a specific structure
+tags:
+- round-2

--- a/data/schemes/MAYO.yaml
+++ b/data/schemes/MAYO.yaml
@@ -32,5 +32,7 @@ versions:
     signing_cycles: 471028
     verification_cycles: 153266
   warning: There is an attack on a parameterset with a specific structure
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/MEDS.yaml
+++ b/data/schemes/MEDS.yaml
@@ -1,0 +1,48 @@
+name: MEDS
+website: https://www.meds-pqc.org/
+category: Code-based
+assumption: Matrix Code Equivalence
+versions:
+- version: v1.0.1
+  date: '2023-06-30'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '134180'
+    level: 5
+    pk: 134180
+    sig: 132528
+    signing_cycles: 1629840000
+    verification_cycles: 1612560000
+  - name: '41711'
+    level: 3
+    pk: 41711
+    sig: 41080
+    signing_cycles: 1467000000
+    verification_cycles: 1461970000
+  - name: '167717'
+    level: 5
+    pk: 167717
+    sig: 165464
+    signing_cycles: 961800000
+    verification_cycles: 938890000
+  - name: '9923'
+    level: 1
+    pk: 9923
+    sig: 9896
+    signing_cycles: 518050000
+    verification_cycles: 515580000
+  - name: '69497'
+    level: 3
+    pk: 55604
+    sig: 54736
+    signing_cycles: 386270000
+    verification_cycles: 380700000
+  - name: '13220'
+    level: 1
+    pk: 13220
+    sig: 12976
+    signing_cycles: 88900000
+    verification_cycles: 87480000
+  info: original reference implementation has an implementation flaw

--- a/data/schemes/MIRA.yaml
+++ b/data/schemes/MIRA.yaml
@@ -1,0 +1,47 @@
+name: MIRA
+website: https://pqc-mira.org/
+category: MPC-in-the-Head
+assumption: MinRank
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256S
+    level: 5
+    pk: 150
+    sig: 20762
+    signing_cycles: 337700000
+    verification_cycles: 331400000
+  - name: 256F
+    level: 5
+    pk: 150
+    sig: 27678
+    signing_cycles: 322300000
+    verification_cycles: 323200000
+  - name: 192S
+    level: 3
+    pk: 121
+    sig: 11779
+    signing_cycles: 119700000
+    verification_cycles: 116200000
+  - name: 192F
+    level: 3
+    pk: 121
+    sig: 15540
+    signing_cycles: 107200000
+    verification_cycles: 107000000
+  - name: 128S
+    level: 1
+    pk: 84
+    sig: 5640
+    signing_cycles: 46800000
+    verification_cycles: 43900000
+  - name: 128F
+    level: 1
+    pk: 84
+    sig: 7376
+    signing_cycles: 37400000
+    verification_cycles: 36700000

--- a/data/schemes/ML-DSA.yaml
+++ b/data/schemes/ML-DSA.yaml
@@ -1,0 +1,27 @@
+name: ML-DSA
+website: https://pq-crystals.org/dilithium
+category: Lattices
+assumption: MLWE/MSIS
+versions:
+- version: FIPS 204
+  date: '2024-08-13'
+  status: FIPS
+  parametersets:
+  - name: ML-DSA-87
+    level: 5
+    pk: 2592
+    sig: 4627
+    signing_cycles: 642192
+    verification_cycles: 279936
+  - name: ML-DSA-65
+    level: 3
+    pk: 1952
+    sig: 3309
+    signing_cycles: 529106
+    verification_cycles: 179424
+  - name: ML-DSA-44
+    level: 2
+    pk: 1312
+    sig: 2420
+    signing_cycles: 333013
+    verification_cycles: 118412

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -1,0 +1,153 @@
+name: MQOM
+website: https://mqom.org
+category: MPC-in-the-Head
+assumption: Multivariate Quadratic
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: L1-gf2-short-3r
+    level: 1
+    pk: 52
+    sig: 2868
+    signing_cycles: 26520000
+    verification_cycles: 25110000
+  - name: L1-gf256-short-3r
+    level: 1
+    pk: 80
+    sig: 3540
+    signing_cycles: 21930000
+    verification_cycles: 20600000
+  - name: L1-gf2-fast-3r
+    level: 1
+    pk: 52
+    sig: 3212
+    signing_cycles: 14120000
+    verification_cycles: 11690000
+  - name: L1-gf256-fast-3r
+    level: 1
+    pk: 80
+    sig: 4164
+    signing_cycles: 7010000
+    verification_cycles: 5070000
+  - name: L3-gf2-short-3r
+    level: 3
+    pk: 78
+    sig: 6388
+    signing_cycles: 11490000
+    verification_cycles: 10360000
+  - name: L3-gf256-short-3r
+    level: 3
+    pk: 120
+    sig: 7900
+    signing_cycles: 83850000
+    verification_cycles: 74410000
+  - name: L3-gf2-fast-3r
+    level: 3
+    pk: 78
+    sig: 7576
+    signing_cycles: 57370000
+    verification_cycles: 51190000
+  - name: L3-gf256-fast-3r
+    level: 3
+    pk: 120
+    sig: 9844
+    signing_cycles: 34180000
+    verification_cycles: 24110000
+  - name: L5-gf2-short-3r
+    level: 5
+    pk: 104
+    sig: 11764
+    signing_cycles: 278920000
+    verification_cycles: 266510000
+  - name: L5-gf256-short-3r
+    level: 5
+    pk: 160
+    sig: 14564
+    signing_cycles: 135010000
+    verification_cycles: 121590000
+  - name: L5-gf2-fast-3r
+    level: 5
+    pk: 104
+    sig: 13412
+    signing_cycles: 145510000
+    verification_cycles: 129970000
+  - name: L5-gf256-fast-3r
+    level: 5
+    pk: 160
+    sig: 17444
+    signing_cycles: 54690000
+    verification_cycles: 36220000
+  - name: L1-gf2-short-5r
+    level: 1
+    pk: 52
+    sig: 2820
+    signing_cycles: 31840000
+    verification_cycles: 30080000
+  - name: L1-gf256-short-5r
+    level: 1
+    pk: 80
+    sig: 3156
+    signing_cycles: 17650000
+    verification_cycles: 16450000
+  - name: L1-gf2-fast-5r
+    level: 1
+    pk: 52
+    sig: 3144
+    signing_cycles: 14530000
+    verification_cycles: 11930000
+  - name: L1-gf256-fast-5r
+    level: 1
+    pk: 80
+    sig: 3620
+    signing_cycles: 6150000
+    verification_cycles: 4280000
+  - name: L3-gf2-short-5r
+    level: 3
+    pk: 78
+    sig: 6280
+    signing_cycles: 108120000
+    verification_cycles: 99360000
+  - name: L3-gf256-short-5r
+    level: 3
+    pk: 120
+    sig: 7036
+    signing_cycles: 66710000
+    verification_cycles: 57490000
+  - name: L3-gf2-fast-5r
+    level: 3
+    pk: 78
+    sig: 7414
+    signing_cycles: 56850000
+    verification_cycles: 50390000
+  - name: L3-gf256-fast-5r
+    level: 3
+    pk: 120
+    sig: 8548
+    signing_cycles: 27470000
+    verification_cycles: 18710000
+  - name: L5-gf2-short-5r
+    level: 5
+    pk: 104
+    sig: 11564
+    signing_cycles: 306940000
+    verification_cycles: 28907000
+  - name: L5-gf256-short-5r
+    level: 5
+    pk: 160
+    sig: 12964
+    signing_cycles: 124980000
+    verification_cycles: 109730000
+  - name: L5-gf2-fast-5r
+    level: 5
+    pk: 104
+    sig: 13124
+    signing_cycles: 150650000
+    verification_cycles: 135980000
+  - name: L5-gf256-fast-5r
+    level: 5
+    pk: 160
+    sig: 15140
+    signing_cycles: 52640000
+    verification_cycles: 33690000

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -153,5 +153,3 @@ versions:
     verification_cycles: 33690000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -153,3 +153,81 @@ versions:
     verification_cycles: 33690000
   tags:
   - round-2
+- version: v1.0
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: L1-gf31-short
+    level: 1
+    pk: 47
+    sig: 6352
+    signing_cycles: 44400000
+    verification_cycles: 41720000
+  - name: L1-gf251-short
+    level: 1
+    pk: 59
+    sig: 6578
+    signing_cycles: 28500000
+    verification_cycles: 27300000
+  - name: L1-gf31-fast
+    level: 1
+    pk: 47
+    sig: 7657
+    signing_cycles: 17700000
+    verification_cycles: 15500000
+  - name: L1-gf251-fast
+    level: 1
+    pk: 59
+    sig: 7850
+    signing_cycles: 11500000
+    verification_cycles: 10200000
+  - name: L3-gf31-short
+    level: 3
+    pk: 73
+    sig: 13846
+    signing_cycles: 108000000
+    verification_cycles: 102000000
+  - name: L3-gf251-short
+    level: 3
+    pk: 92
+    sig: 14266
+    signing_cycles: 69500000
+    verification_cycles: 65600000
+  - name: L3-gf31-fast
+    level: 3
+    pk: 73
+    sig: 16669
+    signing_cycles: 56300000
+    verification_cycles: 51300000
+  - name: L3-gf251-fast
+    level: 3
+    pk: 92
+    sig: 17252
+    signing_cycles: 32900000
+    verification_cycles: 29600000
+  - name: L5-gf31-short
+    level: 5
+    pk: 99
+    sig: 24158
+    signing_cycles: 224000000
+    verification_cycles: 214000000
+  - name: L5-gf251-short
+    level: 5
+    pk: 125
+    sig: 24942
+    signing_cycles: 148000000
+    verification_cycles: 142000000
+  - name: L5-gf31-fast
+    level: 5
+    pk: 99
+    sig: 29036
+    signing_cycles: 156000000
+    verification_cycles: 146000000
+  - name: L5-gf251-fast
+    level: 5
+    pk: 125
+    sig: 30092
+    signing_cycles: 81600000
+    verification_cycles: 75600000

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -35,8 +35,8 @@ versions:
     level: 3
     pk: 78
     sig: 6388
-    signing_cycles: 11490000
-    verification_cycles: 10360000
+    signing_cycles: 114900000
+    verification_cycles: 103600000
   - name: L3-gf256-short-3r
     level: 3
     pk: 120
@@ -132,7 +132,7 @@ versions:
     pk: 104
     sig: 11564
     signing_cycles: 306940000
-    verification_cycles: 28907000
+    verification_cycles: 289070000
   - name: L5-gf256-short-5r
     level: 5
     pk: 160

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -151,5 +151,7 @@ versions:
     sig: 15140
     signing_cycles: 52640000
     verification_cycles: 33690000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/MQOM.yaml
+++ b/data/schemes/MQOM.yaml
@@ -3,8 +3,8 @@ website: https://mqom.org
 category: MPC-in-the-Head
 assumption: Multivariate Quadratic
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: L1-gf2-short-3r
@@ -151,3 +151,5 @@ versions:
     sig: 15140
     signing_cycles: 52640000
     verification_cycles: 33690000
+tags:
+- round-2

--- a/data/schemes/MiRitH.yaml
+++ b/data/schemes/MiRitH.yaml
@@ -1,0 +1,227 @@
+name: MiRitH
+website: https://github.com/Crypto-TII/mirith_nist_submission/
+category: MPC-in-the-Head
+assumption: MinRank
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: hypercube-Vb shortest
+    level: 5
+    pk: 274
+    sig: 18292
+    signing_cycles: 17465014934
+    verification_cycles: 16113973548
+  - name: hypercube-Va shortest
+    level: 5
+    pk: 253
+    sig: 17552
+    signing_cycles: 16708044999
+    verification_cycles: 16535614637
+  - name: hypercube-IIIb shortest
+    level: 3
+    pk: 205
+    sig: 10314
+    signing_cycles: 9878242731
+    verification_cycles: 10063176060
+  - name: hypercube-IIIa shortest
+    level: 3
+    pk: 205
+    sig: 9954
+    signing_cycles: 9861041315
+    verification_cycles: 9651788738
+  - name: hypercube-Ia shortest
+    level: 1
+    pk: 129
+    sig: 4536
+    signing_cycles: 6108117293
+    verification_cycles: 6195562217
+  - name: hypercube-Ib shortest
+    level: 1
+    pk: 144
+    sig: 4886
+    signing_cycles: 6107588818
+    verification_cycles: 6040512181
+  - name: hypercube-Vb shorter
+    level: 5
+    pk: 274
+    sig: 20394
+    signing_cycles: 1359468059
+    verification_cycles: 1278699748
+  - name: hypercube-Va shorter
+    level: 5
+    pk: 253
+    sig: 19393
+    signing_cycles: 1290986430
+    verification_cycles: 1272158929
+  - name: hypercube-IIIb shorter
+    level: 3
+    pk: 205
+    sig: 11202
+    signing_cycles: 727245043
+    verification_cycles: 732036291
+  - name: hypercube-IIIa shorter
+    level: 3
+    pk: 205
+    sig: 10746
+    signing_cycles: 723105845
+    verification_cycles: 708260445
+  - name: hypercube-Ib shorter
+    level: 1
+    pk: 144
+    sig: 5491
+    signing_cycles: 458671636
+    verification_cycles: 450442537
+  - name: hypercube-Ia shorter
+    level: 1
+    pk: 129
+    sig: 5036
+    signing_cycles: 455493593
+    verification_cycles: 456564597
+  - name: Vb short
+    level: 5
+    pk: 274
+    sig: 23182
+    signing_cycles: 327068513
+    verification_cycles: 330632038
+  - name: Va short
+    level: 5
+    pk: 253
+    sig: 21795
+    signing_cycles: 308565196
+    verification_cycles: 310604452
+  - name: IIIb short
+    level: 3
+    pk: 205
+    sig: 13136
+    signing_cycles: 242531804
+    verification_cycles: 204853275
+  - name: IIIa short
+    level: 3
+    pk: 205
+    sig: 12440
+    signing_cycles: 192858411
+    verification_cycles: 175520472
+  - name: hypercube-Vb short
+    level: 5
+    pk: 274
+    sig: 23182
+    signing_cycles: 138497686
+    verification_cycles: 138624970
+  - name: hypercube-Va short
+    level: 5
+    pk: 253
+    sig: 21795
+    signing_cycles: 118493608
+    verification_cycles: 113191871
+  - name: Ia short
+    level: 1
+    pk: 129
+    sig: 5673
+    signing_cycles: 76549995
+    verification_cycles: 76874731
+  - name: hypercube-IIIb short
+    level: 3
+    pk: 205
+    sig: 13136
+    signing_cycles: 71813403
+    verification_cycles: 75999541
+  - name: hypercube-IIIa short
+    level: 3
+    pk: 205
+    sig: 12440
+    signing_cycles: 70251731
+    verification_cycles: 67659810
+  - name: Ib short
+    level: 1
+    pk: 144
+    sig: 6309
+    signing_cycles: 65630977
+    verification_cycles: 65551641
+  - name: hypercube-Ib short
+    level: 1
+    pk: 144
+    sig: 6309
+    signing_cycles: 42086140
+    verification_cycles: 42047669
+  - name: hypercube-Ia short
+    level: 1
+    pk: 129
+    sig: 5673
+    signing_cycles: 41220707
+    verification_cycles: 40976634
+  - name: hypercube-Vb fast
+    level: 5
+    pk: 274
+    sig: 33048
+    signing_cycles: 40665696
+    verification_cycles: 34718714
+  - name: Vb fast
+    level: 5
+    pk: 274
+    sig: 33048
+    signing_cycles: 38659453
+    verification_cycles: 38122610
+  - name: Va fast
+    level: 5
+    pk: 253
+    sig: 30458
+    signing_cycles: 36361915
+    verification_cycles: 36665342
+  - name: hypercube-Va fast
+    level: 5
+    pk: 253
+    sig: 30458
+    signing_cycles: 33245024
+    verification_cycles: 28269718
+  - name: IIIb fast
+    level: 3
+    pk: 205
+    sig: 18459
+    signing_cycles: 24538474
+    verification_cycles: 22470437
+  - name: IIIa fast
+    level: 3
+    pk: 205
+    sig: 17139
+    signing_cycles: 22485807
+    verification_cycles: 18431919
+  - name: hypercube-IIIb fast
+    level: 3
+    pk: 205
+    sig: 18459
+    signing_cycles: 18384614
+    verification_cycles: 15550479
+  - name: hypercube-IIIa fast
+    level: 3
+    pk: 205
+    sig: 17139
+    signing_cycles: 15571845
+    verification_cycles: 13030031
+  - name: hypercube-Ib fast
+    level: 1
+    pk: 144
+    sig: 9105
+    signing_cycles: 9462556
+    verification_cycles: 7914458
+  - name: Ia fast
+    level: 1
+    pk: 129
+    sig: 7877
+    signing_cycles: 8703311
+    verification_cycles: 7311069
+  - name: Ib fast
+    level: 1
+    pk: 144
+    sig: 9105
+    signing_cycles: 8015345
+    verification_cycles: 7558761
+  - name: hypercube-Ia fast
+    level: 1
+    pk: 129
+    sig: 7877
+    signing_cycles: 7246084
+    verification_cycles: 6061955

--- a/data/schemes/Mirath.yaml
+++ b/data/schemes/Mirath.yaml
@@ -71,7 +71,7 @@ versions:
     level: 5
     pk: 147
     sig: 15504
-    signing_cycles: 88700000
+    signing_cycles: 86700000
     verification_cycles: 65100000
   - name: 5b-Fast
     level: 5

--- a/data/schemes/Mirath.yaml
+++ b/data/schemes/Mirath.yaml
@@ -79,5 +79,7 @@ versions:
     sig: 14262
     signing_cycles: 121000000
     verification_cycles: 88000000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/Mirath.yaml
+++ b/data/schemes/Mirath.yaml
@@ -3,8 +3,8 @@ website: https://pqc-mirath.org/
 category: MPC-in-the-Head
 assumption: Min-rank problem
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: 1a-Short
@@ -79,3 +79,5 @@ versions:
     sig: 14262
     signing_cycles: 121000000
     verification_cycles: 88000000
+tags:
+- round-2

--- a/data/schemes/Mirath.yaml
+++ b/data/schemes/Mirath.yaml
@@ -1,0 +1,81 @@
+name: Mirath
+website: https://pqc-mirath.org/
+category: MPC-in-the-Head
+assumption: Min-rank problem
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: 1a-Short
+    level: 1
+    pk: 73
+    sig: 3078
+    signing_cycles: 166000000
+    verification_cycles: 123000000
+  - name: 1b-Short
+    level: 1
+    pk: 57
+    sig: 2902
+    signing_cycles: 152000000
+    verification_cycles: 101000000
+  - name: 1a-Fast
+    level: 1
+    pk: 73
+    sig: 3728
+    signing_cycles: 11000000
+    verification_cycles: 9800000
+  - name: 1b-Fast
+    level: 1
+    pk: 57
+    sig: 3456
+    signing_cycles: 15100000
+    verification_cycles: 12200000
+  - name: 3a-Short
+    level: 3
+    pk: 107
+    sig: 6907
+    signing_cycles: 597000000
+    verification_cycles: 411000000
+  - name: 3b-Short
+    level: 3
+    pk: 84
+    sig: 6514
+    signing_cycles: 520000000
+    verification_cycles: 327000000
+  - name: 3a-Fast
+    level: 3
+    pk: 107
+    sig: 8537
+    signing_cycles: 33600000
+    verification_cycles: 34400000
+  - name: 3b-Fast
+    level: 3
+    pk: 84
+    sig: 7936
+    signing_cycles: 55000000
+    verification_cycles: 51600000
+  - name: 5a-Short
+    level: 5
+    pk: 147
+    sig: 12413
+    signing_cycles: 1415000000
+    verification_cycles: 712000000
+  - name: 5b-Short
+    level: 5
+    pk: 112
+    sig: 11620
+    signing_cycles: 1421000000
+    verification_cycles: 630000000
+  - name: 5a-Fast
+    level: 5
+    pk: 147
+    sig: 15504
+    signing_cycles: 88700000
+    verification_cycles: 65100000
+  - name: 5b-Fast
+    level: 5
+    pk: 112
+    sig: 14262
+    signing_cycles: 121000000
+    verification_cycles: 88000000

--- a/data/schemes/Mirath.yaml
+++ b/data/schemes/Mirath.yaml
@@ -81,5 +81,3 @@ versions:
     verification_cycles: 88000000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/PERK.yaml
+++ b/data/schemes/PERK.yaml
@@ -81,5 +81,3 @@ versions:
     verification_cycles: 131000000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/PERK.yaml
+++ b/data/schemes/PERK.yaml
@@ -79,5 +79,7 @@ versions:
     sig: 23000
     signing_cycles: 168000000
     verification_cycles: 131000000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/PERK.yaml
+++ b/data/schemes/PERK.yaml
@@ -1,0 +1,81 @@
+name: PERK
+website: https://pqc-perk.org/
+category: MPC-in-the-Head
+assumption: Permuted Kernel
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: I-fast3
+    level: 1
+    pk: 150
+    sig: 8360
+    signing_cycles: 7300000
+    verification_cycles: 5100000
+  - name: I-fast5
+    level: 1
+    pk: 240
+    sig: 8030
+    signing_cycles: 7000000
+    verification_cycles: 4900000
+  - name: I-short3
+    level: 1
+    pk: 150
+    sig: 6250
+    signing_cycles: 38000000
+    verification_cycles: 27000000
+  - name: I-short5
+    level: 1
+    pk: 240
+    sig: 5780
+    signing_cycles: 35000000
+    verification_cycles: 25000000
+  - name: III-fast3
+    level: 3
+    pk: 230
+    sig: 18800
+    signing_cycles: 15000000
+    verification_cycles: 12000000
+  - name: III-fast5
+    level: 3
+    pk: 370
+    sig: 18000
+    signing_cycles: 15000000
+    verification_cycles: 11000000
+  - name: III-short3
+    level: 3
+    pk: 230
+    sig: 14300
+    signing_cycles: 80000000
+    verification_cycles: 64000000
+  - name: III-short5
+    level: 3
+    pk: 370
+    sig: 13200
+    signing_cycles: 75000000
+    verification_cycles: 59000000
+  - name: V-fast3
+    level: 5
+    pk: 310
+    sig: 33300
+    signing_cycles: 34000000
+    verification_cycles: 27000000
+  - name: V-fast5
+    level: 5
+    pk: 510
+    sig: 31700
+    signing_cycles: 33000000
+    verification_cycles: 26000000
+  - name: V-short3
+    level: 5
+    pk: 310
+    sig: 25100
+    signing_cycles: 182000000
+    verification_cycles: 142000000
+  - name: V-short5
+    level: 5
+    pk: 510
+    sig: 23000
+    signing_cycles: 168000000
+    verification_cycles: 131000000

--- a/data/schemes/PERK.yaml
+++ b/data/schemes/PERK.yaml
@@ -3,8 +3,8 @@ website: https://pqc-perk.org/
 category: MPC-in-the-Head
 assumption: Permuted Kernel
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: I-fast3
@@ -79,3 +79,5 @@ versions:
     sig: 23000
     signing_cycles: 168000000
     verification_cycles: 131000000
+tags:
+- round-2

--- a/data/schemes/PERK.yaml
+++ b/data/schemes/PERK.yaml
@@ -81,3 +81,81 @@ versions:
     verification_cycles: 131000000
   tags:
   - round-2
+- version: v1.0
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V-short3
+    level: 5
+    pk: 310
+    sig: 26400
+    signing_cycles: 185000000
+    verification_cycles: 143000000
+  - name: V-short5
+    level: 5
+    pk: 510
+    sig: 24200
+    signing_cycles: 171000000
+    verification_cycles: 131000000
+  - name: III-short3
+    level: 3
+    pk: 230
+    sig: 15000
+    signing_cycles: 82000000
+    verification_cycles: 65000000
+  - name: III-short5
+    level: 3
+    pk: 370
+    sig: 13800
+    signing_cycles: 77000000
+    verification_cycles: 60000000
+  - name: I-short3
+    level: 1
+    pk: 150
+    sig: 6560
+    signing_cycles: 39000000
+    verification_cycles: 27000000
+  - name: V-fast3
+    level: 5
+    pk: 310
+    sig: 33300
+    signing_cycles: 36000000
+    verification_cycles: 28000000
+  - name: I-short5
+    level: 1
+    pk: 240
+    sig: 6060
+    signing_cycles: 36000000
+    verification_cycles: 25000000
+  - name: V-fast5
+    level: 5
+    pk: 510
+    sig: 31700
+    signing_cycles: 34000000
+    verification_cycles: 26000000
+  - name: III-fast3
+    level: 3
+    pk: 230
+    sig: 18800
+    signing_cycles: 16000000
+    verification_cycles: 13000000
+  - name: III-fast5
+    level: 3
+    pk: 370
+    sig: 18000
+    signing_cycles: 15000000
+    verification_cycles: 12000000
+  - name: I-fast3
+    level: 1
+    pk: 150
+    sig: 8350
+    signing_cycles: 7600000
+    verification_cycles: 5300000
+  - name: I-fast5
+    level: 1
+    pk: 240
+    sig: 8030
+    signing_cycles: 7200000
+    verification_cycles: 5100000

--- a/data/schemes/PREON.yaml
+++ b/data/schemes/PREON.yaml
@@ -1,0 +1,65 @@
+name: PREON
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/Preon-spec-web.pdf
+category: Other
+assumption: zk-SNARK
+versions:
+- version: Round 1
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256A
+    level: 5
+    pk: 64
+    sig: 598000
+    signing_ms: 414713.0
+    verification_ms: 11552.0
+  - name: 256B
+    level: 5
+    pk: 64
+    sig: 1157000
+    signing_ms: 415207.0
+    verification_ms: 12487.0
+  - name: 256C
+    level: 5
+    pk: 64
+    sig: 5248000
+    signing_ms: 417464.0
+    verification_ms: 26835.0
+  - name: 192A
+    level: 3
+    pk: 56
+    sig: 312000
+    signing_ms: 132411.0
+    verification_ms: 2182.0
+  - name: 192B
+    level: 3
+    pk: 56
+    sig: 778000
+    signing_ms: 137306.0
+    verification_ms: 2688.0
+  - name: 192C
+    level: 3
+    pk: 56
+    sig: 3541000
+    signing_ms: 137252.0
+    verification_ms: 7460.0
+  - name: 128A
+    level: 1
+    pk: 32
+    sig: 139000
+    signing_ms: 76067.0
+    verification_ms: 397.0
+  - name: 128B
+    level: 1
+    pk: 32
+    sig: 372000
+    signing_ms: 80870.0
+    verification_ms: 561.0
+  - name: 128C
+    level: 1
+    pk: 32
+    sig: 1725000
+    signing_ms: 76919.0
+    verification_ms: 2303.0

--- a/data/schemes/PROV.yaml
+++ b/data/schemes/PROV.yaml
@@ -1,0 +1,30 @@
+name: PROV
+website: https://prov-sign.github.io/
+category: Multivariate
+assumption: Multivariate
+versions:
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V
+    level: 5
+    pk: 524192
+    sig: 304
+    signing_ms: 136.66
+    verification_ms: 182.48
+  - name: III
+    level: 3
+    pk: 215694
+    sig: 232
+    signing_ms: 59.04
+    verification_ms: 79.08
+  - name: I
+    level: 1
+    pk: 68326
+    sig: 160
+    signing_ms: 17.71
+    verification_ms: 24.0
+  info: PROV v1.0 leaks the private key. Use v1.1

--- a/data/schemes/QR-UOV.yaml
+++ b/data/schemes/QR-UOV.yaml
@@ -79,5 +79,7 @@ versions:
     sig: 662
     signing_cycles: 347789000
     verification_cycles: 329495000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/QR-UOV.yaml
+++ b/data/schemes/QR-UOV.yaml
@@ -81,3 +81,81 @@ versions:
     verification_cycles: 329495000
   tags:
   - round-2
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V-(127, 306, 105, 3)
+    level: 5
+    pk: 173708
+    sig: 392
+    signing_cycles: 4254736000
+    verification_cycles: 1169402000
+  - name: III-(127, 228, 78, 3)
+    level: 3
+    pk: 71915
+    sig: 292
+    signing_cycles: 1555131000
+    verification_cycles: 524886000
+  - name: V-(31, 1120, 120, 10)
+    level: 5
+    pk: 58564
+    sig: 807
+    signing_cycles: 1074835000
+    verification_cycles: 433574000
+  - name: III-(31, 890, 100, 10)
+    level: 3
+    pk: 34423
+    sig: 643
+    signing_cycles: 573433000
+    verification_cycles: 232156000
+  - name: I-(127, 156, 54, 3)
+    level: 1
+    pk: 24271
+    sig: 200
+    signing_cycles: 361728000
+    verification_cycles: 144955000
+  - name: V-(31, 324, 114, 3)
+    level: 5
+    pk: 158453
+    sig: 306
+    signing_cycles: 337483000
+    verification_cycles: 119098000
+  - name: V-(7, 1490, 190, 10)
+    level: 5
+    pk: 135439
+    sig: 662
+    signing_cycles: 221341000
+    verification_cycles: 10865000
+  - name: III-(31, 246, 87, 3)
+    level: 3
+    pk: 71007
+    sig: 232
+    signing_cycles: 153006000
+    verification_cycles: 5349000
+  - name: I-(31, 600, 70, 10)
+    level: 1
+    pk: 12282
+    sig: 435
+    signing_cycles: 135849000
+    verification_cycles: 68947000
+  - name: III-(7, 1100, 140, 10)
+    level: 3
+    pk: 55173
+    sig: 489
+    signing_cycles: 98376000
+    verification_cycles: 47636000
+  - name: I-(31, 165, 60, 3)
+    level: 1
+    pk: 23657
+    sig: 157
+    signing_cycles: 25217000
+    verification_cycles: 15973000
+  - name: I-(7, 740, 100, 10)
+    level: 1
+    pk: 20657
+    sig: 331
+    signing_cycles: 24823000
+    verification_cycles: 13539000

--- a/data/schemes/QR-UOV.yaml
+++ b/data/schemes/QR-UOV.yaml
@@ -3,8 +3,8 @@ website: http://info.isl.ntt.co.jp/crypt/qruov/index.html
 category: Multivariate
 assumption: Multivariate
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: Round 2
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: I-(127 156 54 3)
@@ -79,3 +79,5 @@ versions:
     sig: 662
     signing_cycles: 347789000
     verification_cycles: 329495000
+tags:
+- round-2

--- a/data/schemes/QR-UOV.yaml
+++ b/data/schemes/QR-UOV.yaml
@@ -1,0 +1,81 @@
+name: QR-UOV
+website: http://info.isl.ntt.co.jp/crypt/qruov/index.html
+category: Multivariate
+assumption: Multivariate
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: I-(127 156 54 3)
+    level: 1
+    pk: 24255
+    sig: 200
+    signing_cycles: 3130000
+    verification_cycles: 2748000
+  - name: I-(31 165 60 3)
+    level: 1
+    pk: 23641
+    sig: 157
+    signing_cycles: 4222000
+    verification_cycles: 3691000
+  - name: I-(31 600 70 10)
+    level: 1
+    pk: 12266
+    sig: 435
+    signing_cycles: 15010000
+    verification_cycles: 15113000
+  - name: I-(7 740 100 10)
+    level: 1
+    pk: 20641
+    sig: 331
+    signing_cycles: 46819000
+    verification_cycles: 44924000
+  - name: III-(127 228 78 3)
+    level: 3
+    pk: 71891
+    sig: 292
+    signing_cycles: 9824000
+    verification_cycles: 8604000
+  - name: III-(31 246 87 3)
+    level: 3
+    pk: 70983
+    sig: 232
+    signing_cycles: 14469000
+    verification_cycles: 12737000
+  - name: III-(31 890 100 10)
+    level: 3
+    pk: 34399
+    sig: 643
+    signing_cycles: 49818000
+    verification_cycles: 48728000
+  - name: III-(7 1100 140 10)
+    level: 3
+    pk: 55149
+    sig: 489
+    signing_cycles: 134929000
+    verification_cycles: 128632000
+  - name: V-(127 306 105 3)
+    level: 5
+    pk: 173676
+    sig: 392
+    signing_cycles: 23880000
+    verification_cycles: 20950000
+  - name: V-(31 1120 120 10)
+    level: 5
+    pk: 58532
+    sig: 807
+    signing_cycles: 90682000
+    verification_cycles: 87848000
+  - name: V-(31 324 114 3)
+    level: 5
+    pk: 158421
+    sig: 306
+    signing_cycles: 30072000
+    verification_cycles: 26157000
+  - name: V-(7 1490 190 10)
+    level: 5
+    pk: 135407
+    sig: 662
+    signing_cycles: 347789000
+    verification_cycles: 329495000

--- a/data/schemes/QR-UOV.yaml
+++ b/data/schemes/QR-UOV.yaml
@@ -81,5 +81,3 @@ versions:
     verification_cycles: 329495000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/RSA.yaml
+++ b/data/schemes/RSA.yaml
@@ -1,0 +1,16 @@
+name: RSA
+website: https://web.archive.org/web/20230127011251/http://people.csail.mit.edu/rivest/Rsapaper.pdf
+category: Pre-Quantum
+assumption: Factoring
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: Classic cryptography
+  parametersets:
+  - name: '2048'
+    level: Pre-Quantum
+    pk: 272
+    sig: 256
+    signing_cycles: 27000000
+    verification_cycles: 45000
+  broken: classical

--- a/data/schemes/RYDE.yaml
+++ b/data/schemes/RYDE.yaml
@@ -43,5 +43,7 @@ versions:
     sig: 14609
     signing_cycles: 49000000
     verification_cycles: 44500000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/RYDE.yaml
+++ b/data/schemes/RYDE.yaml
@@ -45,5 +45,3 @@ versions:
     verification_cycles: 44500000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/RYDE.yaml
+++ b/data/schemes/RYDE.yaml
@@ -45,3 +45,45 @@ versions:
     verification_cycles: 44500000
   tags:
   - round-2
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256S
+    level: 5
+    pk: 188
+    sig: 22802
+    signing_cycles: 105500000
+    verification_cycles: 94900000
+  - name: 192S
+    level: 3
+    pk: 131
+    sig: 12933
+    signing_cycles: 49600000
+    verification_cycles: 44800000
+  - name: 256F
+    level: 5
+    pk: 188
+    sig: 29134
+    signing_cycles: 26000000
+    verification_cycles: 22700000
+  - name: 128S
+    level: 1
+    pk: 86
+    sig: 5956
+    signing_cycles: 23400000
+    verification_cycles: 20100000
+  - name: 192F
+    level: 3
+    pk: 131
+    sig: 16380
+    signing_cycles: 12200000
+    verification_cycles: 10700000
+  - name: 128F
+    level: 1
+    pk: 86
+    sig: 7446
+    signing_cycles: 5400000
+    verification_cycles: 4400000

--- a/data/schemes/RYDE.yaml
+++ b/data/schemes/RYDE.yaml
@@ -3,8 +3,8 @@ website: https://pqc-ryde.org/
 category: MPC-in-the-Head
 assumption: Rank Syndrome Decoding
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: 1-Short
@@ -43,3 +43,5 @@ versions:
     sig: 14609
     signing_cycles: 49000000
     verification_cycles: 44500000
+tags:
+- round-2

--- a/data/schemes/RYDE.yaml
+++ b/data/schemes/RYDE.yaml
@@ -1,0 +1,45 @@
+name: RYDE
+website: https://pqc-ryde.org/
+category: MPC-in-the-Head
+assumption: Rank Syndrome Decoding
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: 1-Short
+    level: 1
+    pk: 69
+    sig: 2988
+    signing_cycles: 71600000
+    verification_cycles: 66300000
+  - name: 1-Fast
+    level: 1
+    pk: 69
+    sig: 3597
+    signing_cycles: 6700000
+    verification_cycles: 6600000
+  - name: 3-Short
+    level: 3
+    pk: 101
+    sig: 6728
+    signing_cycles: 320000000
+    verification_cycles: 282200000
+  - name: 3-Fast
+    level: 3
+    pk: 101
+    sig: 8264
+    signing_cycles: 27300000
+    verification_cycles: 27100000
+  - name: 5-Short
+    level: 5
+    pk: 133
+    sig: 11819
+    signing_cycles: 639300000
+    verification_cycles: 456800000
+  - name: 5-Fast
+    level: 5
+    pk: 133
+    sig: 14609
+    signing_cycles: 49000000
+    verification_cycles: 44500000

--- a/data/schemes/Raccoon.yaml
+++ b/data/schemes/Raccoon.yaml
@@ -1,0 +1,119 @@
+name: Raccoon
+website: https://raccoonfamily.org/
+category: Lattices
+assumption: MLWE/MSIS
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256-32
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 135111000
+    verification_cycles: 4554000
+  - name: 192-32
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 98984000
+    verification_cycles: 2764000
+  - name: 128-32
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 74140000
+    verification_cycles: 1757000
+  - name: 256-16
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 42732000
+    verification_cycles: 4554000
+  - name: 256-8
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 33433000
+    verification_cycles: 4554000
+  - name: 192-16
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 30574000
+    verification_cycles: 2764000
+  - name: 192-8
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 24099000
+    verification_cycles: 2764000
+  - name: 128-16
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 22588000
+    verification_cycles: 1757000
+  - name: 128-8
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 17658000
+    verification_cycles: 1757000
+  - name: 256-4
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 13174000
+    verification_cycles: 4554000
+  - name: 256-2
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 11123000
+    verification_cycles: 4554000
+  - name: 256-1
+    level: 5
+    pk: 4064
+    sig: 20330
+    signing_cycles: 10062000
+    verification_cycles: 4554000
+  - name: 192-4
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 9064000
+    verification_cycles: 2764000
+  - name: 192-2
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 7697000
+    verification_cycles: 2764000
+  - name: 192-1
+    level: 3
+    pk: 3160
+    sig: 14544
+    signing_cycles: 6860000
+    verification_cycles: 2764000
+  - name: 128-4
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 6465000
+    verification_cycles: 1757000
+  - name: 128-2
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 5412000
+    verification_cycles: 1757000
+  - name: 128-1
+    level: 1
+    pk: 2256
+    sig: 11524
+    signing_cycles: 4817000
+    verification_cycles: 1757000

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -24,7 +24,7 @@ versions:
     pk: 98
     sig: 7964
     signing_ms: 42.26
-    verification_ms: 39.84
+    verification_ms: 39.83
   - name: SDitH2-L3-gf2-fast
     level: 3
     pk: 98

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -3,8 +3,8 @@ website: https://sdith.org/
 category: MPC-in-the-Head
 assumption: Syndrome Decoding
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: SDitH2-L1-gf2-short
@@ -43,3 +43,5 @@ versions:
     sig: 17540
     signing_ms: 9.42
     verification_ms: 8.7
+tags:
+- round-2

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -1,0 +1,45 @@
+name: SDitH
+website: https://sdith.org/
+category: MPC-in-the-Head
+assumption: Syndrome Decoding
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: SDitH2-L1-gf2-short
+    level: 1
+    pk: 70
+    sig: 3705
+    signing_ms: 6.73
+    verification_ms: 6.04
+  - name: SDitH2-L1-gf2-fast
+    level: 1
+    pk: 70
+    sig: 4484
+    signing_ms: 2.01
+    verification_ms: 1.79
+  - name: SDitH2-L3-gf2-short
+    level: 3
+    pk: 98
+    sig: 7964
+    signing_ms: 42.26
+    verification_ms: 39.84
+  - name: SDitH2-L3-gf2-fast
+    level: 3
+    pk: 98
+    sig: 9916
+    signing_ms: 6.36
+    verification_ms: 5.75
+  - name: SDitH2-L5-gf2-short
+    level: 5
+    pk: 132
+    sig: 14121
+    signing_ms: 60.48
+    verification_ms: 57.23
+  - name: SDitH2-L5-gf2-fast
+    level: 5
+    pk: 132
+    sig: 17540
+    signing_ms: 9.42
+    verification_ms: 8.7

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -45,5 +45,3 @@ versions:
     verification_ms: 8.7
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -45,3 +45,82 @@ versions:
     verification_ms: 8.7
   tags:
   - round-2
+- version: v1.0
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: gf251-L5-hyp
+    level: 5
+    pk: 234
+    sig: 33370
+    signing_cycles: 94800000
+    verification_cycles: 91300000
+  - name: gf256-L5-hyp
+    level: 5
+    pk: 234
+    sig: 33370
+    signing_cycles: 59200000
+    verification_cycles: 54400000
+  - name: gf251-L3-hyp
+    level: 3
+    pk: 183
+    sig: 19161
+    signing_cycles: 51100000
+    verification_cycles: 49000000
+  - name: gf256-L3-hyp
+    level: 3
+    pk: 183
+    sig: 19161
+    signing_cycles: 30500000
+    verification_cycles: 27700000
+  - name: gf256-L5-thr
+    level: 5
+    pk: 234
+    sig: 43943
+    signing_cycles: 30500000
+    verification_cycles: 10200000
+  - name: gf251-L5-thr
+    level: 5
+    pk: 234
+    sig: 43943
+    signing_cycles: 23900000
+    verification_cycles: 3200000
+  - name: gf251-L1-hyp
+    level: 1
+    pk: 120
+    sig: 8241
+    signing_cycles: 22100000
+    verification_cycles: 21200000
+  - name: gf256-L3-thr
+    level: 3
+    pk: 183
+    sig: 24918
+    signing_cycles: 14800000
+    verification_cycles: 4900000
+  - name: gf256-L1-hyp
+    level: 1
+    pk: 120
+    sig: 8241
+    signing_cycles: 13400000
+    verification_cycles: 12500000
+  - name: gf251-L3-thr
+    level: 3
+    pk: 183
+    sig: 24918
+    signing_cycles: 11700000
+    verification_cycles: 1500000
+  - name: gf256-L1-thr
+    level: 1
+    pk: 120
+    sig: 10117
+    signing_cycles: 5100000
+    verification_cycles: 1600000
+  - name: gf251-L1-thr
+    level: 1
+    pk: 120
+    sig: 10117
+    signing_cycles: 4400000
+    verification_cycles: 600000
+  info: few bits security loss in original parameters

--- a/data/schemes/SDitH.yaml
+++ b/data/schemes/SDitH.yaml
@@ -43,5 +43,7 @@ versions:
     sig: 17540
     signing_ms: 9.42
     verification_ms: 8.7
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/SLH-DSA.yaml
+++ b/data/schemes/SLH-DSA.yaml
@@ -1,0 +1,45 @@
+name: SLH-DSA
+website: https://sphincs.org/
+category: Symmetric
+assumption: Hash-based
+versions:
+- version: FIPS 205
+  date: '2024-08-13'
+  status: FIPS
+  parametersets:
+  - name: SHAKE-192s
+    level: 3
+    pk: 48
+    sig: 16224
+    signing_cycles: 8091419556
+    verification_cycles: 6465506
+  - name: SHAKE-256s
+    level: 5
+    pk: 64
+    sig: 29792
+    signing_cycles: 7085272100
+    verification_cycles: 10216560
+  - name: SHAKE-128s
+    level: 1
+    pk: 32
+    sig: 7856
+    signing_cycles: 4682570992
+    verification_cycles: 4764084
+  - name: SHAKE-256f
+    level: 5
+    pk: 64
+    sig: 49856
+    signing_cycles: 763942250
+    verification_cycles: 19886032
+  - name: SHAKE-192f
+    level: 3
+    pk: 48
+    sig: 35664
+    signing_cycles: 386861992
+    verification_cycles: 19876926
+  - name: SHAKE-128f
+    level: 1
+    pk: 32
+    sig: 17088
+    signing_cycles: 239793806
+    verification_cycles: 12909924

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -62,5 +62,7 @@ versions:
     signing_cycles: 338723
     verification_cycles: 146738
   warning: Attacks have reduced the security of the scheme
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -64,5 +64,3 @@ versions:
   warning: Attacks have reduced the security of the scheme
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -11,56 +11,68 @@ versions:
     level: 5
     pk: 8016
     sig: 576
-    signing_cycles: 3110898
-    verification_cycles: 1504945
+    signing_cycles: 2800653
+    verification_cycles: 1932041
   - name: (66 15 3)
     level: 5
     pk: 15204
     sig: 381
-    signing_cycles: 3546746
-    verification_cycles: 2460059
+    signing_cycles: 2215902
+    verification_cycles: 1737533
   - name: (75 33 2)
     level: 5
     pk: 71890
-    sig: 216
-    signing_cycles: 2304920
-    verification_cycles: 1165161
-  - name: (37 8 14)
+    sig: 232
+    signing_cycles: 1426465
+    verification_cycles: 1309034
+  - name: (29 6 5)
+    level: 5
+    pk: 2716
+    sig: 454
+    signing_cycles: 1758416
+    verification_cycles: 1073040
+  - name: (37 8 4)
     level: 3
     pk: 4112
     sig: 376
-    signing_cycles: 1188690
-    verification_cycles: 544395
+    signing_cycles: 1102301
+    verification_cycles: 652463
   - name: (49 11 3)
     level: 3
     pk: 6006
     sig: 286
-    signing_cycles: 1365463
-    verification_cycles: 1004519
+    signing_cycles: 984405
+    verification_cycles: 675680
   - name: (56 25 2)
     level: 3
     pk: 31266
-    sig: 168
-    signing_cycles: 964716
-    verification_cycles: 507009
+    sig: 178
+    signing_cycles: 648245
+    verification_cycles: 531159
+  - name: (24 5 5)
+    level: 3
+    pk: 1579
+    sig: 379
+    signing_cycles: 1120762
+    verification_cycles: 685307
   - name: (24 5 4)
     level: 1
     pk: 1016
     sig: 248
-    signing_cycles: 306736
-    verification_cycles: 163805
+    signing_cycles: 385429
+    verification_cycles: 205829
   - name: (25 8 3)
     level: 1
     pk: 2320
     sig: 165
-    signing_cycles: 370046
-    verification_cycles: 218801
+    signing_cycles: 340740
+    verification_cycles: 176153
   - name: (37 17 2)
     level: 1
     pk: 9842
-    sig: 106
-    signing_cycles: 338723
-    verification_cycles: 146738
+    sig: 124
+    signing_cycles: 262422
+    verification_cycles: 151842
   warning: Attacks have reduced the security of the scheme
   tags:
   - round-2

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -64,3 +64,63 @@ versions:
   warning: Attacks have reduced the security of the scheme
   tags:
   - round-2
+- version: Round 1
+  date: '2023-05-25'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: (60, 10, 16, 4)
+    level: 5
+    pk: 8016
+    sig: 576
+    signing_cycles: 237150613
+    verification_cycles: 90472932
+  - name: (66, 15, 16, 3)
+    level: 5
+    pk: 15204
+    sig: 381
+    signing_cycles: 172139775
+    verification_cycles: 47936266
+  - name: (61, 33, 16, 2)
+    level: 5
+    pk: 71890
+    sig: 204
+    signing_cycles: 158443732
+    verification_cycles: 25289616
+  - name: (37, 8, 16, 4)
+    level: 3
+    pk: 4112
+    sig: 376
+    signing_cycles: 81382976
+    verification_cycles: 31084401
+  - name: (49, 11, 16, 3)
+    level: 3
+    pk: 6006
+    sig: 286
+    signing_cycles: 60561733
+    verification_cycles: 18853861
+  - name: (43, 25, 16, 2)
+    level: 3
+    pk: 31266
+    sig: 152
+    signing_cycles: 47587816
+    verification_cycles: 9443639
+  - name: (24, 5, 16, 4)
+    level: 1
+    pk: 1016
+    sig: 248
+    signing_cycles: 19681409
+    verification_cycles: 8086815
+  - name: (25, 8, 16, 3)
+    level: 1
+    pk: 2320
+    sig: 165
+    signing_cycles: 12408096
+    verification_cycles: 3959869
+  - name: (28, 17, 16, 2)
+    level: 1
+    pk: 9842
+    sig: 106
+    signing_cycles: 10964945
+    verification_cycles: 3161199

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -3,8 +3,8 @@ website: http://snova.pqclab.org/
 category: Multivariate
 assumption: Non-commutative ring UOV
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-01-25'
   status: On-ramp
   parametersets:
   - name: (60 10 4)
@@ -62,3 +62,5 @@ versions:
     signing_cycles: 338723
     verification_cycles: 146738
   warning: Attacks have reduced the security of the scheme
+tags:
+- round-2

--- a/data/schemes/SNOVA.yaml
+++ b/data/schemes/SNOVA.yaml
@@ -1,0 +1,64 @@
+name: SNOVA
+website: http://snova.pqclab.org/
+category: Multivariate
+assumption: Non-commutative ring UOV
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: (60 10 4)
+    level: 5
+    pk: 8016
+    sig: 576
+    signing_cycles: 3110898
+    verification_cycles: 1504945
+  - name: (66 15 3)
+    level: 5
+    pk: 15204
+    sig: 381
+    signing_cycles: 3546746
+    verification_cycles: 2460059
+  - name: (75 33 2)
+    level: 5
+    pk: 71890
+    sig: 216
+    signing_cycles: 2304920
+    verification_cycles: 1165161
+  - name: (37 8 14)
+    level: 3
+    pk: 4112
+    sig: 376
+    signing_cycles: 1188690
+    verification_cycles: 544395
+  - name: (49 11 3)
+    level: 3
+    pk: 6006
+    sig: 286
+    signing_cycles: 1365463
+    verification_cycles: 1004519
+  - name: (56 25 2)
+    level: 3
+    pk: 31266
+    sig: 168
+    signing_cycles: 964716
+    verification_cycles: 507009
+  - name: (24 5 4)
+    level: 1
+    pk: 1016
+    sig: 248
+    signing_cycles: 306736
+    verification_cycles: 163805
+  - name: (25 8 3)
+    level: 1
+    pk: 2320
+    sig: 165
+    signing_cycles: 370046
+    verification_cycles: 218801
+  - name: (37 17 2)
+    level: 1
+    pk: 9842
+    sig: 106
+    signing_cycles: 338723
+    verification_cycles: 146738
+  warning: Attacks have reduced the security of the scheme

--- a/data/schemes/SPHINCS-alpha.yaml
+++ b/data/schemes/SPHINCS-alpha.yaml
@@ -1,0 +1,83 @@
+name: SPHINCS-alpha
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/sphincs-alpha-spec-web.pdf
+category: Symmetric
+assumption: hash-based
+versions:
+- version: Round 1
+  date: '2023-05-31'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: 256s SHAKE
+    level: 5
+    pk: 64
+    sig: 27232
+    signing_cycles: 1996754616
+    verification_cycles: 7254738
+  - name: 256f SHAKE
+    level: 5
+    pk: 64
+    sig: 49312
+    signing_cycles: 1582371720
+    verification_cycles: 11677806
+  - name: 192f SHAKE
+    level: 3
+    pk: 48
+    sig: 34896
+    signing_cycles: 92073114
+    verification_cycles: 3028500
+  - name: 256s SHA2
+    level: 5
+    pk: 64
+    sig: 27232
+    signing_cycles: 764352612
+    verification_cycles: 6005448
+  - name: 256f SHA2
+    level: 5
+    pk: 64
+    sig: 49312
+    signing_cycles: 91335474
+    verification_cycles: 3175290
+  - name: 192f SHA2
+    level: 3
+    pk: 48
+    sig: 34896
+    signing_cycles: 45218790
+    verification_cycles: 1744038
+  - name: 192s SHAKE
+    level: 3
+    pk: 48
+    sig: 14568
+    signing_cycles: 1996754616
+    verification_cycles: 7254738
+  - name: 128f SHAKE
+    level: 1
+    pk: 32
+    sig: 16720
+    signing_cycles: 57069090
+    verification_cycles: 3558492
+  - name: 192s SHA2
+    level: 3
+    pk: 48
+    sig: 14568
+    signing_cycles: 988899534
+    verification_cycles: 3845970
+  - name: 128s SHAKE
+    level: 1
+    pk: 32
+    sig: 6880
+    signing_cycles: 1139743980
+    verification_cycles: 4891482
+  - name: 128f SHA2
+    level: 1
+    pk: 32
+    sig: 16720
+    signing_cycles: 26635716
+    verification_cycles: 2028186
+  - name: 128s SHA2
+    level: 1
+    pk: 32
+    sig: 6880
+    signing_cycles: 537033762
+    verification_cycles: 2689650

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -27,5 +27,3 @@ versions:
     verification_cycles: 5100000
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -1,0 +1,27 @@
+name: SQIsign
+website: https://sqisign.org/
+category: Isogenies
+assumption: Isogenies
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: V
+    level: 5
+    pk: 129
+    sig: 292
+    signing_cycles: 507500000
+    verification_cycles: 35700000
+  - name: III
+    level: 3
+    pk: 97
+    sig: 224
+    signing_cycles: 309200000
+    verification_cycles: 18600000
+  - name: I
+    level: 1
+    pk: 65
+    sig: 148
+    signing_cycles: 101600000
+    verification_cycles: 5100000

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -27,3 +27,27 @@ versions:
     verification_cycles: 5100000
   tags:
   - round-2
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V
+    level: 5
+    pk: 128
+    sig: 335
+    signing_cycles: 158544000000
+    verification_cycles: 2177000000
+  - name: III
+    level: 3
+    pk: 96
+    sig: 263
+    signing_cycles: 43760000000
+    verification_cycles: 654000000
+  - name: I
+    level: 1
+    pk: 64
+    sig: 177
+    signing_cycles: 5669000000
+    verification_cycles: 108000000

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -25,5 +25,7 @@ versions:
     sig: 148
     signing_cycles: 101600000
     verification_cycles: 5100000
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -3,8 +3,8 @@ website: https://sqisign.org/
 category: Isogenies
 assumption: Isogenies
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: V
@@ -25,3 +25,5 @@ versions:
     sig: 148
     signing_cycles: 101600000
     verification_cycles: 5100000
+tags:
+- round-2

--- a/data/schemes/Squirrels.yaml
+++ b/data/schemes/Squirrels.yaml
@@ -1,0 +1,41 @@
+name: Squirrels
+website: https://www.squirrels-pqc.org/
+category: Lattices
+assumption: SIS
+versions:
+- version: Round 1
+  date: '2023-06-02'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V
+    level: 5
+    pk: 2786580
+    sig: 2025
+    signing_cycles: 10670614
+    verification_cycles: 481938
+  - name: VI
+    level: 4
+    pk: 1888700
+    sig: 1676
+    signing_cycles: 9097631
+    verification_cycles: 329066
+  - name: III
+    level: 3
+    pk: 1629640
+    sig: 1554
+    signing_cycles: 7139278
+    verification_cycles: 287974
+  - name: II
+    level: 2
+    pk: 874576
+    sig: 1147
+    signing_cycles: 3732387
+    verification_cycles: 159887
+  - name: I
+    level: 1
+    pk: 681780
+    sig: 1019
+    signing_cycles: 3164772
+    verification_cycles: 145351

--- a/data/schemes/TUOV.yaml
+++ b/data/schemes/TUOV.yaml
@@ -1,0 +1,35 @@
+name: TUOV
+website: https://www.tuovsig.org/
+category: Multivariate
+assumption: UOV
+versions:
+- version: v1.0
+  date: '2023-05-30'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V
+    level: 5
+    pk: 442384
+    sig: 244
+    signing_cycles: 1133958
+    verification_cycles: 4520748
+  - name: III
+    level: 3
+    pk: 186640
+    sig: 184
+    signing_cycles: 608604
+    verification_cycles: 1914056
+  - name: Is
+    level: 1
+    pk: 65552
+    sig: 80
+    signing_cycles: 272394
+    verification_cycles: 570194
+  - name: Ip
+    level: 1
+    pk: 42608
+    sig: 112
+    signing_cycles: 220792
+    verification_cycles: 491120

--- a/data/schemes/UOV.yaml
+++ b/data/schemes/UOV.yaml
@@ -56,5 +56,7 @@ versions:
     signing_cycles: 109328
     verification_cycles: 80342
   warning: There is an attack on some parametersets with a specific structure
+  tags:
+  - round-2
 tags:
 - round-2

--- a/data/schemes/UOV.yaml
+++ b/data/schemes/UOV.yaml
@@ -58,5 +58,3 @@ versions:
   warning: There is an attack on some parametersets with a specific structure
   tags:
   - round-2
-tags:
-- round-2

--- a/data/schemes/UOV.yaml
+++ b/data/schemes/UOV.yaml
@@ -1,0 +1,58 @@
+name: UOV
+website: https://www.uovsig.org/
+category: Multivariate
+assumption: Multivariate
+versions:
+- version: initial
+  date: '2024-10-01'
+  status: On-ramp
+  parametersets:
+  - name: V-pkc
+    level: 5
+    pk: 446992
+    sig: 260
+    signing_cycles: 591144
+    verification_cycles: 2017472
+  - name: V-classic
+    level: 5
+    pk: 2869440
+    sig: 260
+    signing_cycles: 591144
+    verification_cycles: 530468
+  - name: III-pkc
+    level: 3
+    pk: 189232
+    sig: 200
+    signing_cycles: 302728
+    verification_cycles: 963800
+  - name: III-classic
+    level: 3
+    pk: 1225440
+    sig: 200
+    signing_cycles: 302728
+    verification_cycles: 282514
+  - name: Is-pkc
+    level: 1
+    pk: 66576
+    sig: 96
+    signing_cycles: 128972
+    verification_cycles: 282842
+  - name: Is-classic
+    level: 1
+    pk: 412160
+    sig: 96
+    signing_cycles: 128972
+    verification_cycles: 60916
+  - name: Ip-pkc
+    level: 1
+    pk: 43576
+    sig: 128
+    signing_cycles: 109328
+    verification_cycles: 235006
+  - name: Ip-classic
+    level: 1
+    pk: 278432
+    sig: 128
+    signing_cycles: 109328
+    verification_cycles: 80342
+  warning: There is an attack on some parametersets with a specific structure

--- a/data/schemes/UOV.yaml
+++ b/data/schemes/UOV.yaml
@@ -3,8 +3,8 @@ website: https://www.uovsig.org/
 category: Multivariate
 assumption: Multivariate
 versions:
-- version: initial
-  date: '2024-10-01'
+- version: v2.0
+  date: '2025-02-05'
   status: On-ramp
   parametersets:
   - name: V-pkc
@@ -56,3 +56,5 @@ versions:
     signing_cycles: 109328
     verification_cycles: 80342
   warning: There is an attack on some parametersets with a specific structure
+tags:
+- round-2

--- a/data/schemes/UOV.yaml
+++ b/data/schemes/UOV.yaml
@@ -58,3 +58,57 @@ versions:
   warning: There is an attack on some parametersets with a specific structure
   tags:
   - round-2
+- version: v1.0
+  date: '2023-05-30'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: V-pkc
+    level: 5
+    pk: 446992
+    sig: 260
+    signing_cycles: 591812
+    verification_cycles: 2032992
+  - name: V-classic
+    level: 5
+    pk: 2869440
+    sig: 260
+    signing_cycles: 591812
+    verification_cycles: 470886
+  - name: III-pkc
+    level: 3
+    pk: 189232
+    sig: 200
+    signing_cycles: 299316
+    verification_cycles: 917402
+  - name: III-classic
+    level: 3
+    pk: 1225440
+    sig: 200
+    signing_cycles: 299316
+    verification_cycles: 241588
+  - name: Is-pkc
+    level: 1
+    pk: 66576
+    sig: 96
+    signing_cycles: 109314
+    verification_cycles: 276520
+  - name: Is-classic
+    level: 1
+    pk: 412160
+    sig: 96
+    signing_cycles: 109314
+    verification_cycles: 58274
+  - name: Ip-pkc
+    level: 1
+    pk: 43576
+    sig: 128
+    signing_cycles: 105324
+    verification_cycles: 224006
+  - name: Ip-classic
+    level: 1
+    pk: 278432
+    sig: 128
+    signing_cycles: 105324
+    verification_cycles: 90336

--- a/data/schemes/VOX.yaml
+++ b/data/schemes/VOX.yaml
@@ -1,0 +1,29 @@
+name: VOX
+website: http://vox-sign.com/
+category: Multivariate
+assumption: Multivariate
+versions:
+- version: v1.0
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '256'
+    level: 5
+    pk: 82400
+    sig: 300
+    signing_cycles: 12110394
+    verification_cycles: 1585504
+  - name: '192'
+    level: 3
+    pk: 30351
+    sig: 184
+    signing_cycles: 2709851
+    verification_cycles: 713968
+  - name: '128'
+    level: 1
+    pk: 9104
+    sig: 102
+    signing_cycles: 664265
+    verification_cycles: 168567

--- a/data/schemes/Wave.yaml
+++ b/data/schemes/Wave.yaml
@@ -1,0 +1,29 @@
+name: Wave
+website: https://wave-sign.org/
+category: Code-based
+assumption: Coding theory
+versions:
+- version: v1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: '1644'
+    level: 5
+    pk: 13632308
+    sig: 1644
+    signing_cycles: 7397000000
+    verification_cycles: 813300000
+  - name: '1249'
+    level: 3
+    pk: 7867598
+    sig: 1249
+    signing_cycles: 3507000000
+    verification_cycles: 464100000
+  - name: '822'
+    level: 1
+    pk: 3677390
+    sig: 822
+    signing_cycles: 1161000000
+    verification_cycles: 205800000

--- a/data/schemes/Xifrat1-Sign.I.yaml
+++ b/data/schemes/Xifrat1-Sign.I.yaml
@@ -1,0 +1,18 @@
+name: Xifrat1-Sign.I
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/xifrat1-sign-i-spec.pdf
+category: Other
+assumption: randomized abelian quasigroups
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: I
+    level: 3
+    pk: 288
+    sig: 96
+    signing_ms: 20.0
+    verification_ms: 60.0
+  broken: secret key recovery

--- a/data/schemes/eMLE-Sig_2.0.yaml
+++ b/data/schemes/eMLE-Sig_2.0.yaml
@@ -1,0 +1,30 @@
+name: eMLE-Sig 2.0
+website: https://csrc.nist.gov/csrc/media/Projects/pqc-dig-sig/documents/round-1/spec-files/eMLE-spec-web.pdf
+category: Other
+assumption: Embedded Multilayer Equations
+versions:
+- version: Round 1
+  date: '2023-06-01'
+  status: On-ramp
+  tags:
+  - round-1
+  parametersets:
+  - name: Level V
+    level: 5
+    pk: 960
+    sig: 640
+    signing_cycles: 114965
+    verification_cycles: 63110
+  - name: Level III
+    level: 3
+    pk: 672
+    sig: 456
+    signing_cycles: 80653
+    verification_cycles: 38175
+  - name: Level I
+    level: 1
+    pk: 416
+    sig: 280
+    signing_cycles: 52597
+    verification_cycles: 21755
+  broken: secret key recovery

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
 				"@tailwindcss/vite": "^4.2.2",
 				"@types/js-yaml": "^4.0.9",
+				"@types/node": "^25.6.0",
 				"js-yaml": "^4.1.1",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.4.6",
@@ -836,6 +837,16 @@
 			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -2150,6 +2161,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vega": {
 			"version": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
 				"@sveltejs/kit": "^2.57.0",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
 				"@tailwindcss/vite": "^4.2.2",
+				"@types/js-yaml": "^4.0.9",
+				"js-yaml": "^4.1.1",
 				"svelte": "^5.55.2",
 				"svelte-check": "^4.4.6",
 				"tailwindcss": "^4.2.2",
@@ -828,6 +830,13 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/@types/js-yaml": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+			"integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -873,6 +882,13 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.1",
@@ -1413,6 +1429,19 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/json-stringify-pretty-compact": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.2",
+		"@types/js-yaml": "^4.0.9",
+		"js-yaml": "^4.1.1",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
 		"tailwindcss": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/js-yaml": "^4.0.9",
+		"@types/node": "^25.6.0",
 		"js-yaml": "^4.1.1",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",

--- a/scripts/add_round1.py
+++ b/scripts/add_round1.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["pyyaml"]
+# ///
+"""Add round-1 version entries from round-1/data/ CSVs into data/schemes/ YAML files.
+
+For schemes already in data/schemes/ (round-2 survivors): prepend a round-1
+version entry with round-1 paramsets and version info.
+For round-1-only schemes: create new YAML files.
+Skips reference/classical schemes (EdDSA, RSA, Falcon, ML-DSA, SLH-DSA).
+"""
+
+import csv
+import re
+import yaml
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+R1_DATA = ROOT / "round-1" / "data"
+SCHEMES_DIR = ROOT / "data" / "schemes"
+
+# ── round-1 version strings from spec PDFs ──────────────────────────────────
+R1_VERSION = {
+    # schemes that survived to round-2
+    "CROSS":    ("Round 1", "2023-06-02"),
+    "FAEST":    ("v1.0",    "2023-06-01"),
+    "HAWK":     ("v1.0",    "2023-06-01"),
+    "LESS":     ("Round 1", "2023-06-01"),
+    "MAYO":     ("Round 1", "2023-06-01"),
+    "MQOM":     ("v1.0",    "2023-05-31"),
+    "PERK":     ("v1.0",    "2023-05-31"),
+    "QR-UOV":   ("Round 1", "2023-06-01"),
+    "RYDE":     ("Round 1", "2023-06-01"),
+    "SDitH":    ("v1.0",    "2023-05-31"),
+    "SNOVA":    ("Round 1", "2023-05-25"),
+    "SQIsign":  ("v1.0",    "2023-06-01"),
+    "UOV":      ("v1.0",    "2023-05-30"),
+    # round-1-only (non-broken)
+    "AIMer":         ("v1.0",    "2023-06-01"),
+    "ALTEQ":         ("Round 1", "2023-06-01"),
+    "Ascon-Sign":    ("Round 1", "2023-06-01"),
+    "Biscuit":       ("Round 1", "2023-06-01"),
+    "FuLeeca":       ("Round 1", "2023-05-31"),
+    "HAETAE":        ("Round 1", "2023-05-31"),
+    "HuFu":          ("Round 1", "2023-06-01"),
+    "MEDS":          ("v1.0.1",  "2023-06-30"),
+    "MIRA":          ("Round 1", "2023-06-01"),
+    "MiRitH":        ("Round 1", "2023-06-01"),
+    "PREON":         ("Round 1", "2023-05-31"),
+    "PROV":          ("v1.0",    "2023-06-01"),
+    "Raccoon":       ("Round 1", "2023-06-01"),
+    "SPHINCS-alpha": ("Round 1", "2023-05-31"),
+    "Squirrels":     ("Round 1", "2023-06-02"),
+    "TUOV":          ("v1.0",    "2023-05-30"),
+    "VOX":           ("v1.0",    "2023-06-01"),
+    "Wave":          ("v1",      "2023-06-01"),
+    # broken schemes
+    "3WISE":            ("Round 1", "2023-06-01"),
+    "DME-Sign":         ("Round 1", "2023-06-01"),
+    "EagleSign":        ("Round 1", "2023-06-01"),
+    "EHTv3 / EHTv4":    ("Round 1", "2023-06-01"),
+    "eMLE-Sig 2.0":     ("Round 1", "2023-06-01"),
+    "Enhanced pqsigRM": ("Round 1", "2023-06-01"),
+    "HPPC":             ("Round 1", "2023-06-01"),
+    "KAZ-Sign":         ("Round 1", "2023-06-01"),
+    "Xifrat1-Sign.I":   ("Round 1", "2023-06-01"),
+}
+
+# Not additional-signature submissions — skip entirely
+SKIP = {"EdDSA", "RSA", "Falcon", "ML-DSA (Dilithium)", "SLH-DSA (SPHINCS+)"}
+
+# CSV name → YAML scheme name (for schemes that changed name round-1→round-2)
+CSV_TO_YAML_NAME = {
+    "QR-UOV": "QR-UOV",  # same, just confirming
+}
+
+
+def sanitize(name: str) -> str:
+    return re.sub(r"_+", "_", name.replace("/", "_").replace(" ", "_").replace("(", "").replace(")", ""))
+
+
+def parse_num(s: str):
+    s = s.replace(",", "").strip()
+    if not s:
+        return None
+    try:
+        f = float(s)
+        return int(f) if f == int(f) else f
+    except ValueError:
+        return None
+
+
+# ── Load round-1 CSVs ────────────────────────────────────────────────────────
+with open(R1_DATA / "schemes.csv") as f:
+    r1_schemes = {r["Scheme"]: r for r in csv.DictReader(f)}
+
+with open(R1_DATA / "parametersets.csv") as f:
+    r1_paramsets: dict[str, list] = defaultdict(list)
+    for r in csv.DictReader(f):
+        r1_paramsets[r["Scheme"]].append(r)
+
+
+def build_paramsets(csv_rows: list) -> list:
+    result = []
+    for ps in csv_rows:
+        level_raw = ps["Security level"]
+        level = level_raw if level_raw == "Pre-Quantum" else int(level_raw)
+
+        pk = parse_num(ps["pk size"])
+        sig = parse_num(ps["sig size"])
+        sign_cyc = parse_num(ps["signing (cycles)"])
+        verif_cyc = parse_num(ps["verification (cycles)"])
+        sign_ms = parse_num(ps["signing (ms)"])
+        verif_ms = parse_num(ps["verification (ms)"])
+
+        entry: dict = {"name": ps["Parameterset"], "level": level, "pk": pk, "sig": sig}
+        if sign_cyc:
+            entry["signing_cycles"] = sign_cyc
+            entry["verification_cycles"] = verif_cyc
+        elif sign_ms is not None:
+            entry["signing_ms"] = float(sign_ms)
+            entry["verification_ms"] = float(verif_ms) if verif_ms is not None else None
+        result.append(entry)
+    return result
+
+
+def build_version(csv_scheme: dict, paramsets: list, version: str, date: str) -> dict:
+    v: dict = {
+        "version": version,
+        "date": date,
+        "status": csv_scheme["NIST status"],
+        "tags": ["round-1"],
+        "parametersets": paramsets,
+    }
+    if csv_scheme.get("Broken"):
+        v["broken"] = csv_scheme["Broken"]
+    if csv_scheme.get("Warning"):
+        v["warning"] = csv_scheme["Warning"]
+    if csv_scheme.get("Info"):
+        v["info"] = csv_scheme["Info"]
+    return v
+
+
+# ── Existing YAML files (round-2 survivors) ──────────────────────────────────
+existing_yaml_names = {p.stem: p for p in SCHEMES_DIR.glob("*.yaml")}
+
+for csv_name, csv_scheme in r1_schemes.items():
+    if csv_name in SKIP:
+        continue
+
+    yaml_name = CSV_TO_YAML_NAME.get(csv_name, csv_name)
+    yaml_file = SCHEMES_DIR / f"{yaml_name}.yaml"
+
+    if not yaml_file.exists():
+        continue  # handled below for new files
+
+    version, date = R1_VERSION.get(csv_name, ("Round 1", "2023-06-01"))
+    paramsets = build_paramsets(r1_paramsets[csv_name])
+    if not paramsets:
+        print(f"SKIP {csv_name}: no round-1 paramsets")
+        continue
+
+    r1_version = build_version(csv_scheme, paramsets, version, date)
+
+    with open(yaml_file) as f:
+        doc = yaml.safe_load(f)
+
+    # Append round-1 version (date sorting handles ordering at runtime)
+    doc["versions"].append(r1_version)
+
+    with open(yaml_file, "w") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    print(f"Updated (added round-1): {yaml_file.name}")
+
+
+# ── New YAML files (round-1-only schemes) ────────────────────────────────────
+for csv_name, csv_scheme in r1_schemes.items():
+    if csv_name in SKIP:
+        continue
+
+    yaml_name = CSV_TO_YAML_NAME.get(csv_name, csv_name)
+    yaml_file = SCHEMES_DIR / f"{yaml_name}.yaml"
+
+    if yaml_file.exists():
+        continue  # already handled above
+
+    version, date = R1_VERSION.get(csv_name, ("Round 1", "2023-06-01"))
+    paramsets = build_paramsets(r1_paramsets[csv_name])
+
+    r1_version = build_version(csv_scheme, paramsets, version, date)
+
+    doc = {
+        "name": csv_name,
+        "website": csv_scheme["Website"],
+        "category": csv_scheme["Category"],
+        "assumption": csv_scheme["Assumption"],
+        "versions": [r1_version],
+    }
+
+    filename = sanitize(csv_name) + ".yaml"
+    out_path = SCHEMES_DIR / filename
+    with open(out_path, "w") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    print(f"Created (round-1 only): {filename}")

--- a/scripts/migrate_to_yaml.py
+++ b/scripts/migrate_to_yaml.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = ["pyyaml"]
+# ///
+"""Migrate static/data/{schemes,parametersets}.csv → data/schemes/*.yaml"""
+
+import csv
+import yaml
+from pathlib import Path
+from collections import defaultdict
+
+base = Path(__file__).parent.parent / "static" / "data"
+out_dir = Path(__file__).parent.parent / "data" / "schemes"
+out_dir.mkdir(parents=True, exist_ok=True)
+
+
+def parse_int(s: str) -> int | None:
+    try:
+        v = float(s.replace(",", ""))
+        return int(v) if v else None
+    except (ValueError, AttributeError):
+        return None
+
+
+def parse_float(s: str) -> float | None:
+    try:
+        return float(s) if s else None
+    except (ValueError, AttributeError):
+        return None
+
+
+with open(base / "schemes.csv") as f:
+    schemes = {r["Scheme"]: r for r in csv.DictReader(f)}
+
+with open(base / "parametersets.csv") as f:
+    paramsets: dict[str, list] = defaultdict(list)
+    for r in csv.DictReader(f):
+        paramsets[r["Scheme"]].append(r)
+
+for scheme_name, scheme in schemes.items():
+    filename = scheme_name.replace("/", "_").replace(" ", "_") + ".yaml"
+
+    ps_list = []
+    for ps in paramsets[scheme_name]:
+        level_raw = ps["Security level"]
+        level: int | str = level_raw if level_raw == "Pre-Quantum" else int(level_raw)
+
+        ps_data: dict = {
+            "name": ps["Parameterset"],
+            "level": level,
+            "pk": parse_int(ps["pk size"]),
+            "sig": parse_int(ps["sig size"]),
+        }
+
+        sign_cyc = parse_int(ps["signing (cycles)"])
+        verif_cyc = parse_int(ps["verification (cycles)"])
+        sign_ms = parse_float(ps["signing (ms)"])
+        verif_ms = parse_float(ps["verification (ms)"])
+
+        if sign_cyc:
+            ps_data["signing_cycles"] = sign_cyc
+            ps_data["verification_cycles"] = verif_cyc
+        elif sign_ms is not None:
+            ps_data["signing_ms"] = sign_ms
+            ps_data["verification_ms"] = verif_ms
+
+        ps_list.append(ps_data)
+
+    version: dict = {
+        "version": "initial",
+        # TODO: replace with actual submission/update dates
+        "date": "2024-10-01",
+        "status": scheme["NIST status"],
+        "parametersets": ps_list,
+    }
+    if scheme["Broken"]:
+        version["broken"] = scheme["Broken"]
+    if scheme["Warning"]:
+        version["warning"] = scheme["Warning"]
+    if scheme["Info"]:
+        version["info"] = scheme["Info"]
+
+    doc = {
+        "name": scheme_name,
+        "website": scheme["Website"],
+        "category": scheme["Category"],
+        "assumption": scheme["Assumption"],
+        "versions": [version],
+    }
+
+    with open(out_dir / filename, "w") as f:
+        yaml.dump(doc, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    print(f"Written: {filename}")
+
+print(f"\nDone. {len(schemes)} scheme files written to {out_dir}")

--- a/src/lib/components/ScatterPlot.svelte
+++ b/src/lib/components/ScatterPlot.svelte
@@ -35,6 +35,7 @@
 		const values = data.map((d) => ({
 			scheme: d.scheme,
 			parameterset: d.parameterset,
+			version: d.version || null,
 			pk: d.pk,
 			sig: d.sig,
 			color: colorCat(d),
@@ -104,6 +105,7 @@
 				tooltip: [
 					{ field: 'scheme', type: 'nominal', title: 'Scheme' },
 					{ field: 'parameterset', type: 'nominal', title: 'Parameter set' },
+					{ field: 'version', type: 'nominal', title: 'Version' },
 					{ field: 'pk', type: 'quantitative', title: 'pk (bytes)', format: ',' },
 					{ field: 'sig', type: 'quantitative', title: 'sig (bytes)', format: ',' },
 					{ field: 'notes', type: 'nominal', title: 'Notes' }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -138,7 +138,10 @@ export function parseParameterSets(
 	return { rows, ranges };
 }
 
-export function processYamlSchemes(schemeData: SchemeYaml[]): {
+export function processYamlSchemes(
+	schemeData: SchemeYaml[],
+	tagFilter?: string
+): {
 	schemes: Scheme[];
 	parameterSets: ParameterSet[];
 	ranges: DataRanges;
@@ -149,8 +152,23 @@ export function processYamlSchemes(schemeData: SchemeYaml[]): {
 	for (const yaml of schemeData) {
 		if (!yaml.versions || yaml.versions.length === 0) continue;
 
-		// Latest version = highest date
-		const latest = [...yaml.versions].sort((a, b) => b.date.localeCompare(a.date))[0];
+		const sorted = [...yaml.versions].sort((a, b) => b.date.localeCompare(a.date));
+
+		let latest;
+		if (tagFilter) {
+			// Pick latest version with the requested tag
+			const tagged = sorted.filter((v) => v.tags?.includes(tagFilter));
+			if (tagged.length > 0) {
+				latest = tagged[0];
+			} else if (yaml.versions.every((v) => !v.tags || v.tags.length === 0)) {
+				// Untagged reference scheme — always include
+				latest = sorted[0];
+			} else {
+				continue; // Scheme exists but not in this round
+			}
+		} else {
+			latest = sorted[0];
+		}
 
 		const scheme: Scheme = {
 			scheme: yaml.name,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,5 +1,5 @@
 import { CPUSPEED } from './constants';
-import type { DataRanges, NistLevel, ParameterSet, Scheme } from './types';
+import type { DataRanges, NistLevel, ParameterSet, Scheme, SchemeYaml } from './types';
 
 function parseCsv(text: string): Record<string, string>[] {
 	const lines = text.trim().split('\n');
@@ -49,6 +49,7 @@ export function parseSchemes(csv: string): Scheme[] {
 		warning: d['Warning'] === '' ? false : d['Warning'],
 		info: d['Info'] === '' ? false : d['Info'],
 		classical: d['Broken'] === 'classical',
+		tags: [],
 	}));
 }
 
@@ -110,6 +111,8 @@ export function parseParameterSets(
 			classical: scheme.classical,
 			website: scheme.website,
 			assumption: scheme.assumption,
+			notes: null,
+			version: '',
 		};
 	});
 
@@ -133,4 +136,111 @@ export function parseParameterSets(
 	};
 
 	return { rows, ranges };
+}
+
+export function processYamlSchemes(schemeData: SchemeYaml[]): {
+	schemes: Scheme[];
+	parameterSets: ParameterSet[];
+	ranges: DataRanges;
+} {
+	const schemes: Scheme[] = [];
+	const rows: ParameterSet[] = [];
+
+	for (const yaml of schemeData) {
+		if (!yaml.versions || yaml.versions.length === 0) continue;
+
+		// Latest version = highest date
+		const latest = [...yaml.versions].sort((a, b) => b.date.localeCompare(a.date))[0];
+
+		const scheme: Scheme = {
+			scheme: yaml.name,
+			status: latest.status,
+			website: yaml.website,
+			category: yaml.category,
+			assumption: yaml.assumption,
+			broken: latest.broken ?? false,
+			warning: latest.warning ?? false,
+			info: latest.info ?? false,
+			classical: latest.broken === 'classical',
+			tags: yaml.tags ?? [],
+		};
+		schemes.push(scheme);
+
+		for (const ps of latest.parametersets) {
+			const level: NistLevel =
+				ps.level === 'Pre-Quantum' ? 'Pre-Quantum' : (ps.level as 1 | 2 | 3 | 4 | 5);
+
+			const signingMs = ps.signing_ms ?? null;
+			const verificationMs = ps.verification_ms ?? null;
+
+			let signingCycles: number;
+			let verificationCycles: number;
+			let extrapolated: boolean;
+
+			if (ps.signing_cycles != null && ps.signing_cycles > 0) {
+				extrapolated = false;
+				signingCycles = ps.signing_cycles;
+				verificationCycles = ps.verification_cycles ?? 0;
+			} else {
+				extrapolated = true;
+				signingCycles = signingMs != null ? Math.round((CPUSPEED * signingMs) / 1000) : 0;
+				verificationCycles =
+					verificationMs != null ? Math.round((CPUSPEED * verificationMs) / 1000) : 0;
+			}
+
+			// Parameterset flags fall back to version-level flags
+			const broken = ps.broken ?? latest.broken ?? false;
+			const warning = ps.warning ?? latest.warning ?? false;
+			const info = ps.info ?? latest.info ?? false;
+
+			const pk = ps.pk;
+			const sig = ps.sig;
+
+			rows.push({
+				scheme: yaml.name,
+				parameterset: ps.name,
+				category: yaml.category,
+				status: latest.status,
+				level,
+				pk,
+				sig,
+				pkPlusSig: pk + sig,
+				signingCycles,
+				verificationCycles,
+				signingMs,
+				verificationMs,
+				extrapolated,
+				broken: broken === false ? false : broken || false,
+				warning: warning === false ? false : warning || false,
+				info: info === false ? false : info || false,
+				classical: broken === 'classical',
+				website: yaml.website,
+				assumption: yaml.assumption,
+				notes: ps.notes ?? null,
+				version: latest.version,
+			});
+		}
+	}
+
+	const nonZeroSign = rows.filter((r) => r.signingCycles > 0);
+	const nonZeroVerify = rows.filter((r) => r.verificationCycles > 0);
+
+	const ranges: DataRanges = {
+		pk: [Math.min(...rows.map((r) => r.pk)), Math.max(...rows.map((r) => r.pk))],
+		sig: [Math.min(...rows.map((r) => r.sig)), Math.max(...rows.map((r) => r.sig))],
+		pkPlusSig: [
+			Math.min(...rows.map((r) => r.pkPlusSig)),
+			Math.max(...rows.map((r) => r.pkPlusSig)),
+		],
+		signingCycles: [
+			Math.min(...nonZeroSign.map((r) => r.signingCycles)),
+			Math.max(...nonZeroSign.map((r) => r.signingCycles)),
+		],
+		verificationCycles: [
+			Math.min(...nonZeroVerify.map((r) => r.verificationCycles)),
+			Math.max(...nonZeroVerify.map((r) => r.verificationCycles)),
+		],
+	};
+
+	return { schemes, parameterSets: rows, ranges };
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -162,7 +162,7 @@ export function processYamlSchemes(schemeData: SchemeYaml[]): {
 			warning: latest.warning ?? false,
 			info: latest.info ?? false,
 			classical: latest.broken === 'classical',
-			tags: yaml.tags ?? [],
+			tags: [...new Set(yaml.versions.flatMap((v) => v.tags ?? []))],
 		};
 		schemes.push(scheme);
 

--- a/src/lib/filterStore.ts
+++ b/src/lib/filterStore.ts
@@ -118,9 +118,11 @@ function compareValues(a: ParameterSet, b: ParameterSet, col: SortableColumn): n
 	}
 }
 
-// Module-level store state — initialized by createFilterStore
+// Stable module-level stores — created once, updated in place on round changes
+const _allRows = writable<ParameterSet[]>([]);
 let _store: Writable<FilterState> | null = null;
 let _defaults: FilterState | null = null;
+// _filteredRows derives from both _store and _allRows, so it stays valid across round changes
 let _filteredRows: Readable<ParameterSet[]> | null = null;
 
 export function createFilterStore(
@@ -133,33 +135,40 @@ export function createFilterStore(
 	const initial = applyUrlParams(defaults, urlParams);
 
 	_defaults = defaults;
-	_store = writable(initial);
-	_filteredRows = derived(_store, ($state) => {
-		return allRows
-			.filter((row) => {
-				if (!$state.schemes.has(row.scheme)) return false;
-				if (!$state.levels.has(row.level)) return false;
-				if (row.pk < $state.minPk || row.pk > $state.maxPk) return false;
-				if (row.sig < $state.minSig || row.sig > $state.maxSig) return false;
-				if (row.pkPlusSig < $state.minPkPlusSig || row.pkPlusSig > $state.maxPkPlusSig)
-					return false;
-				if (
-					row.signingCycles < $state.minSigningCycles ||
-					row.signingCycles > $state.maxSigningCycles
-				)
-					return false;
-				if (
-					row.verificationCycles < $state.minVerificationCycles ||
-					row.verificationCycles > $state.maxVerificationCycles
-				)
-					return false;
-				return true;
-			})
-			.sort((a, b) => {
-				const cmp = compareValues(a, b, $state.sortCol);
-				return $state.sortDir === 'asc' ? cmp : -cmp;
-			});
-	});
+	_allRows.set(allRows);
+
+	if (!_store || !_filteredRows) {
+		_store = writable(initial);
+		_filteredRows = derived([_store, _allRows], ([$state, $rows]) => {
+			return $rows
+				.filter((row) => {
+					if (!$state.schemes.has(row.scheme)) return false;
+					if (!$state.levels.has(row.level)) return false;
+					if (row.pk < $state.minPk || row.pk > $state.maxPk) return false;
+					if (row.sig < $state.minSig || row.sig > $state.maxSig) return false;
+					if (row.pkPlusSig < $state.minPkPlusSig || row.pkPlusSig > $state.maxPkPlusSig)
+						return false;
+					if (
+						row.signingCycles < $state.minSigningCycles ||
+						row.signingCycles > $state.maxSigningCycles
+					)
+						return false;
+					if (
+						row.verificationCycles < $state.minVerificationCycles ||
+						row.verificationCycles > $state.maxVerificationCycles
+					)
+						return false;
+					return true;
+				})
+				.sort((a, b) => {
+					const cmp = compareValues(a, b, $state.sortCol);
+					return $state.sortDir === 'asc' ? cmp : -cmp;
+				});
+		});
+	} else {
+		// Round change: reset filter state to new defaults, data already updated via _allRows
+		_store.set(initial);
+	}
 
 	return { store: _store, defaults, filteredRows: _filteredRows };
 }

--- a/src/lib/roundStore.ts
+++ b/src/lib/roundStore.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+
+export type Round = 'round-1' | 'round-2';
+
+export const roundStore = writable<Round>('round-2');

--- a/src/lib/schemeData.ts
+++ b/src/lib/schemeData.ts
@@ -1,0 +1,7 @@
+import type { SchemeYaml } from './types';
+
+const modules = import.meta.glob('../../data/schemes/*.yaml', {
+	eager: true,
+}) as Record<string, { default: SchemeYaml }>;
+
+export const allSchemeData: SchemeYaml[] = Object.values(modules).map((m) => m.default);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,7 +71,6 @@ export interface SchemeYaml {
 	website: string;
 	category: string;
 	assumption: string;
-	tags?: string[];
 	versions: VersionYaml[];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export interface Scheme {
 	warning: false | string;
 	info: false | string;
 	classical: boolean;
+	tags: string[];
 }
 
 export interface ParameterSet {
@@ -32,6 +33,45 @@ export interface ParameterSet {
 	classical: boolean;
 	website: string;
 	assumption: string;
+	notes: string | null;
+	version: string;
+}
+
+// YAML schema types
+
+export interface ParameterSetYaml {
+	name: string;
+	level: number | 'Pre-Quantum';
+	pk: number;
+	sig: number;
+	signing_cycles?: number;
+	verification_cycles?: number;
+	signing_ms?: number;
+	verification_ms?: number;
+	broken?: string;
+	warning?: string;
+	info?: string;
+	notes?: string;
+}
+
+export interface VersionYaml {
+	version: string;
+	date: string;
+	status: string;
+	notes?: string;
+	broken?: string;
+	warning?: string;
+	info?: string;
+	parametersets: ParameterSetYaml[];
+}
+
+export interface SchemeYaml {
+	name: string;
+	website: string;
+	category: string;
+	assumption: string;
+	tags?: string[];
+	versions: VersionYaml[];
 }
 
 export type SortableColumn =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,7 @@ export interface VersionYaml {
 	version: string;
 	date: string;
 	status: string;
+	tags?: string[];
 	notes?: string;
 	broken?: string;
 	warning?: string;

--- a/src/lib/yaml.d.ts
+++ b/src/lib/yaml.d.ts
@@ -1,0 +1,5 @@
+declare module '*.yaml' {
+	import type { SchemeYaml } from './types';
+	const value: SchemeYaml;
+	export default value;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import './layout.css';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import { themeStore } from '$lib/themeStore';
+	import { roundStore, type Round } from '$lib/roundStore';
 
 	let { children } = $props();
 
@@ -10,9 +12,15 @@
 	);
 	const themeLabel = $derived(`Theme: ${$themeStore} — click to cycle`);
 
+	const isHome = $derived($page.url.pathname === '/');
+
 	onMount(() => {
 		themeStore.init();
 	});
+
+	function setRound(r: Round) {
+		roundStore.set(r);
+	}
 </script>
 
 <div class="flex min-h-screen flex-col bg-pqs-smoke text-pqs-midnight dark:bg-pqs-midnight dark:text-pqs-smoke">
@@ -25,12 +33,22 @@
 				</span>
 			</a>
 			<div class="ml-auto flex items-center gap-5 font-heading text-sm">
-				<a
-					href="/round-1/"
-					class="text-pqs-bluegray hover:text-pqs-apricot transition-colors"
-				>
-					Round 1
-				</a>
+				{#if isHome}
+					<div class="flex items-center gap-1 rounded border border-pqs-steel/40 p-0.5 font-heading text-sm">
+						<button
+							onclick={() => setRound('round-2')}
+							class="rounded px-2 py-0.5 transition-colors {$roundStore === 'round-2' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'text-pqs-bluegray hover:text-white'}"
+						>
+							Round 2
+						</button>
+						<button
+							onclick={() => setRound('round-1')}
+							class="rounded px-2 py-0.5 transition-colors {$roundStore === 'round-1' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'text-pqs-bluegray hover:text-white'}"
+						>
+							Round 1
+						</button>
+					</div>
+				{/if}
 				<a
 					href="https://github.com/pqshield/nist-sigs-zoo"
 					target="_blank"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,11 +11,12 @@
 	import { allSchemeData } from '$lib/schemeData';
 	import type { PageData } from './$types';
 
-	let { data }: { data: PageData } = $props();
+	let { data: _ }: { data: PageData } = $props();
 
-	let schemes = $state(data.schemes);
-	let categories = $state(data.categories);
-	let ranges = $state(data.ranges);
+	const _init = processYamlSchemes(allSchemeData, 'round-2');
+	let schemes = $state(_init.schemes);
+	let categories = $state([...new Set(_init.schemes.map((s) => s.category))].sort());
+	let ranges = $state(_init.ranges);
 
 	const { applyUrl } = getFilterStore();
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,35 +39,29 @@
 		// Apply filter URL params
 		if (params.toString()) applyUrl(params);
 
-		// Debounced URL sync on filter changes — re-subscribed on each round change
+		// Debounced URL sync on filter changes
 		let urlSyncTimer: ReturnType<typeof setTimeout> | null = null;
-		let unsubFilter: (() => void) | null = null;
+		const { store, defaults } = getFilterStore();
+		const unsubFilter = store.subscribe((state) => {
+			if (urlSyncTimer) clearTimeout(urlSyncTimer);
+			urlSyncTimer = setTimeout(() => {
+				const p = buildUrlParams(state, defaults);
+				const round = $roundStore === 'round-1' ? '1' : null;
+				if (round) p.set('r', round);
+				const qs = p.toString();
+				const newUrl = qs ? `?${qs}` : $page.url.pathname;
+				goto(newUrl, { replaceState: true, keepFocus: true, noScroll: true });
+			}, 300);
+		});
 
-		function subscribeFilter() {
-			if (unsubFilter) unsubFilter();
-			const { store: currentStore, defaults: currentDefaults } = getFilterStore();
-			unsubFilter = currentStore.subscribe((state) => {
-				if (urlSyncTimer) clearTimeout(urlSyncTimer);
-				urlSyncTimer = setTimeout(() => {
-					const p = buildUrlParams(state, currentDefaults);
-					const round = $roundStore === 'round-1' ? '1' : null;
-					if (round) p.set('r', round);
-					const qs = p.toString();
-					const newUrl = qs ? `?${qs}` : $page.url.pathname;
-					goto(newUrl, { replaceState: true, keepFocus: true, noScroll: true });
-				}, 300);
-			});
-		}
-
-		// Re-process when round changes, then re-subscribe to new filter store
+		// Re-process when round changes — store stays stable, data updates in place
 		const unsubRound = roundStore.subscribe((round) => {
 			applyRound(round);
-			subscribeFilter();
 		});
 
 		return () => {
 			unsubRound();
-			if (unsubFilter) unsubFilter();
+			unsubFilter();
 			if (urlSyncTimer) clearTimeout(urlSyncTimer);
 		};
 	});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,36 +1,73 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
 	import FilterPanel from '$lib/components/FilterPanel.svelte';
 	import SchemeTable from '$lib/components/SchemeTable.svelte';
 	import ScatterPlot from '$lib/components/ScatterPlot.svelte';
-	import { getFilterStore, buildUrlParams } from '$lib/filterStore';
+	import { processYamlSchemes } from '$lib/data';
+	import { getFilterStore, buildUrlParams, createFilterStore } from '$lib/filterStore';
+	import { roundStore, type Round } from '$lib/roundStore';
+	import { allSchemeData } from '$lib/schemeData';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 
-	const { store, defaults, applyUrl } = getFilterStore();
+	let schemes = $state(data.schemes);
+	let categories = $state(data.categories);
+	let ranges = $state(data.ranges);
+
+	const { applyUrl } = getFilterStore();
+
+	function applyRound(round: Round) {
+		const result = processYamlSchemes(allSchemeData, round);
+		schemes = result.schemes;
+		categories = [...new Set(result.schemes.map((s) => s.category))].sort();
+		ranges = result.ranges;
+		createFilterStore(result.parameterSets, result.ranges, new URLSearchParams());
+	}
 
 	onMount(() => {
-		// Apply URL params now that we're on the client
+		// Apply round from URL (?r=1 or ?r=2)
 		const params = new URLSearchParams(window.location.search);
+		const rParam = params.get('r');
+		if (rParam === '1') {
+			roundStore.set('round-1');
+			applyRound('round-1');
+		}
+
+		// Apply filter URL params
 		if (params.toString()) applyUrl(params);
 
-		// Debounced URL sync on subsequent filter changes
+		// Debounced URL sync on filter changes — re-subscribed on each round change
 		let urlSyncTimer: ReturnType<typeof setTimeout> | null = null;
-		const unsub = store.subscribe((state) => {
-			if (urlSyncTimer) clearTimeout(urlSyncTimer);
-			urlSyncTimer = setTimeout(() => {
-				const p = buildUrlParams(state, defaults);
-				const qs = p.toString();
-				const newUrl = qs ? `?${qs}` : $page.url.pathname;
-				goto(newUrl, { replaceState: true, keepFocus: true, noScroll: true });
-			}, 300);
+		let unsubFilter: (() => void) | null = null;
+
+		function subscribeFilter() {
+			if (unsubFilter) unsubFilter();
+			const { store: currentStore, defaults: currentDefaults } = getFilterStore();
+			unsubFilter = currentStore.subscribe((state) => {
+				if (urlSyncTimer) clearTimeout(urlSyncTimer);
+				urlSyncTimer = setTimeout(() => {
+					const p = buildUrlParams(state, currentDefaults);
+					const round = $roundStore === 'round-1' ? '1' : null;
+					if (round) p.set('r', round);
+					const qs = p.toString();
+					const newUrl = qs ? `?${qs}` : $page.url.pathname;
+					goto(newUrl, { replaceState: true, keepFocus: true, noScroll: true });
+				}, 300);
+			});
+		}
+
+		// Re-process when round changes, then re-subscribe to new filter store
+		const unsubRound = roundStore.subscribe((round) => {
+			applyRound(round);
+			subscribeFilter();
 		});
+
 		return () => {
-			unsub();
+			unsubRound();
+			if (unsubFilter) unsubFilter();
 			if (urlSyncTimer) clearTimeout(urlSyncTimer);
 		};
 	});
@@ -56,7 +93,7 @@
 		<!-- Sidebar filter panel -->
 		<div class="hidden w-60 shrink-0 lg:block">
 			<div class="sticky top-4">
-				<FilterPanel schemes={data.schemes} categories={data.categories} ranges={data.ranges} />
+				<FilterPanel schemes={schemes} categories={categories} ranges={ranges} />
 			</div>
 		</div>
 
@@ -68,7 +105,7 @@
 					Filters ▼
 				</summary>
 				<div class="mt-2 rounded border border-pqs-ashgray bg-white p-3 dark:border-pqs-steel dark:bg-pqs-midnight-mid">
-					<FilterPanel schemes={data.schemes} categories={data.categories} ranges={data.ranges} />
+					<FilterPanel schemes={schemes} categories={categories} ranges={ranges} />
 				</div>
 			</details>
 

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,17 +1,17 @@
-import { parseParameterSets, parseSchemes } from '$lib/data';
+import { processYamlSchemes } from '$lib/data';
 import { createFilterStore } from '$lib/filterStore';
+import type { SchemeYaml } from '$lib/types';
 import type { PageLoad } from './$types';
+
+const schemeModules = import.meta.glob('../../data/schemes/*.yaml', {
+	eager: true,
+}) as Record<string, { default: SchemeYaml }>;
 
 export const prerender = true;
 
-export const load: PageLoad = async ({ fetch, url }) => {
-	const [schemesText, paramsText] = await Promise.all([
-		fetch('/data/schemes.csv').then((r) => r.text()),
-		fetch('/data/parametersets.csv').then((r) => r.text()),
-	]);
-
-	const schemes = parseSchemes(schemesText);
-	const { rows: parameterSets, ranges } = parseParameterSets(paramsText, schemes);
+export const load: PageLoad = async () => {
+	const schemeData = Object.values(schemeModules).map((m) => m.default);
+	const { schemes, parameterSets, ranges } = processYamlSchemes(schemeData);
 
 	const categories = [...new Set(schemes.map((s) => s.category))].sort();
 

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,17 +1,12 @@
 import { processYamlSchemes } from '$lib/data';
 import { createFilterStore } from '$lib/filterStore';
-import type { SchemeYaml } from '$lib/types';
+import { allSchemeData } from '$lib/schemeData';
 import type { PageLoad } from './$types';
-
-const schemeModules = import.meta.glob('../../data/schemes/*.yaml', {
-	eager: true,
-}) as Record<string, { default: SchemeYaml }>;
 
 export const prerender = true;
 
 export const load: PageLoad = async () => {
-	const schemeData = Object.values(schemeModules).map((m) => m.default);
-	const { schemes, parameterSets, ranges } = processYamlSchemes(schemeData);
+	const { schemes, parameterSets, ranges } = processYamlSchemes(allSchemeData, 'round-2');
 
 	const categories = [...new Set(schemes.map((s) => s.category))].sort();
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,24 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import yaml from 'js-yaml';
+
+function yamlPlugin() {
+	return {
+		name: 'yaml-loader',
+		transform(src: string, id: string) {
+			if (id.endsWith('.yaml') || id.endsWith('.yml')) {
+				const parsed = yaml.load(src);
+				return {
+					code: `export default ${JSON.stringify(parsed)}`,
+					map: null,
+				};
+			}
+		},
+	};
+}
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
-	build: { chunkSizeWarningLimit: 1000 }
+	plugins: [yamlPlugin(), tailwindcss(), sveltekit()],
+	build: { chunkSizeWarningLimit: 1000 },
 });


### PR DESCRIPTION
### Summary

  - Replace CSV data with per-scheme YAML files (`data/schemes/*.yaml`). Each file carries full version history with parametersets, security flags, timing data, and round tags. Version selection is tag-based — the site picks
   the latest version tagged `round-2` (or `round-1`) when switching rounds.
  - Add round-1 data for all 40 NIST additional-signatures round-1 submissions, including 13 schemes that advanced to round 2.
  - Add Round 2 / Round 1 toggle in the nav bar. Switching reloads the full dataset (table, scatter plot, filters) without a page navigation. Round is persisted in the URL as `?r=1`.
  - Fix stale store bug: filter store now uses stable writable references updated in place on round changes, so all component subscriptions remain valid.

### Verify round-2 data against spec PDFs

Schemes advancing from round 1 (13):
  - [ ] CROSS
  - [ ] FAEST
  - [ ] HAWK
  - [ ] LESS
  - [ ] MAYO
  - [ ] MQOM
  - [ ] PERK
  - [ ] QR-UOV
  - [ ] RYDE
  - [ ] SDitH
  - [ ] SNOVA
  - [ ] SQIsign
  - [ ] UOV

Round-2 only (1):
  - [ ] Mirath

 ### Verify round-1 data against spec PDFs

  - [ ] 3WISE
  - [ ] AIMer
  - [ ] ALTEQ
  - [ ] Ascon-Sign
  - [ ] Biscuit
  - [ ] CROSS
  - [ ] DME-Sign
  - [ ] EHTv3 / EHTv4
  - [ ] EagleSign
  - [ ] Enhanced pqsigRM
  - [ ] FAEST
  - [ ] FuLeeca
  - [ ] HAETAE
  - [ ] HAWK
  - [ ] HPPC
  - [ ] HuFu
  - [ ] KAZ-Sign
  - [ ] LESS
  - [ ] MAYO
  - [ ] MEDS
  - [ ] MIRA
  - [ ] MiRitH
  - [ ] MQOM
  - [ ] PERK
  - [ ] PREON
  - [ ] PROV
  - [ ] QR-UOV
  - [ ] Raccoon
  - [ ] RYDE
  - [ ] SDitH
  - [ ] SNOVA
  - [ ] SPHINCS-alpha
  - [ ] SQIsign
  - [ ] Squirrels
  - [ ] TUOV
  - [ ] UOV
  - [ ] VOX
  - [ ] Wave
  - [ ] Xifrat1-Sign.I
  - [ ] eMLE-Sig 2.0