### PR TITLE
a11y: replace title-only tooltips with tap-to-reveal badges and legend

### DIFF
--- a/src/lib/components/SchemeTable.svelte
+++ b/src/lib/components/SchemeTable.svelte
@@ -124,6 +124,7 @@
 							<span
 								class="underline decoration-wavy decoration-pqs-scarlet"
 								title="Estimated from {fmtCycles(row.signingCycles)} cycles @ 2.5 GHz"
+								aria-label="{fmtTime(row.signingCycles / 2500)} (estimated from {fmtCycles(row.signingCycles)} cycles @ 2.5 GHz)"
 							>
 								{fmtTime(row.signingCycles / 2500)}
 							</span>
@@ -139,6 +140,7 @@
 							<span
 								class="underline decoration-wavy decoration-pqs-scarlet"
 								title="Estimated from {fmtCycles(row.verificationCycles)} cycles @ 2.5 GHz"
+								aria-label="{fmtTime(row.verificationCycles / 2500)} (estimated from {fmtCycles(row.verificationCycles)} cycles @ 2.5 GHz)"
 							>
 								{fmtTime(row.verificationCycles / 2500)}
 							</span>
@@ -161,5 +163,18 @@
 	</table>
 	<div class="border-t border-pqs-ashgray bg-pqs-smoke px-3 py-1.5 font-heading text-xs text-pqs-steel dark:border-pqs-steel dark:bg-pqs-midnight-mid dark:text-pqs-bluegray">
 		{$filteredRows.length} parameter set{$filteredRows.length === 1 ? '' : 's'}
+	</div>
+	<div class="border-t border-pqs-ashgray bg-pqs-smoke px-3 py-2 text-xs text-pqs-steel/70 dark:border-pqs-steel dark:bg-pqs-midnight-mid dark:text-pqs-bluegray/70">
+		<span class="font-semibold text-pqs-steel dark:text-pqs-bluegray">Legend:</span>
+		<span class="ml-2">💣 pre-quantum (classical security only)</span>
+		<span class="ml-2">·</span>
+		<span class="ml-2">🧨 broken</span>
+		<span class="ml-2">·</span>
+		<span class="ml-2">⚠️ security warning</span>
+		<span class="ml-2">·</span>
+		<span class="ml-2">ℹ️ note</span>
+		<span class="ml-2">·</span>
+		<span class="ml-2"><span class="underline decoration-wavy decoration-pqs-scarlet">value</span> estimated from cycle counts</span>
+		<span class="ml-2">· tap icons for details</span>
 	</div>
 </div>

--- a/src/lib/components/SecurityBadge.svelte
+++ b/src/lib/components/SecurityBadge.svelte
@@ -6,14 +6,55 @@
 		classical: boolean;
 	}
 	let { broken, warning, info, classical }: Props = $props();
+	let expanded = $state(false);
+
+	function toggle(e: MouseEvent | KeyboardEvent) {
+		if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return;
+		e.preventDefault();
+		expanded = !expanded;
+	}
 </script>
 
 {#if classical}
-	<span aria-label="Pre-quantum scheme (not quantum-resistant)" title="Pre-quantum: {broken}">💣</span>
+	<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} onclick={toggle}>💣</button>
+	{#if expanded}
+		<span class="msg msg-muted">Pre-quantum: {broken}</span>
+	{/if}
 {:else if broken}
-	<span aria-label="Broken scheme" title="Broken: {broken}">🧨</span>
+	<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} onclick={toggle}>🧨</button>
+	{#if expanded}
+		<span class="msg msg-danger">Broken: {broken}</span>
+	{/if}
 {:else if warning}
-	<span aria-label="Security warning" title="Warning: {warning}">⚠️</span>
+	<button class="badge" aria-label="Security warning" aria-expanded={expanded} onclick={toggle}>⚠️</button>
+	{#if expanded}
+		<span class="msg msg-warning">Warning: {warning}</span>
+	{/if}
 {:else if info}
-	<span aria-label="Security note" title="Note: {info}">ℹ️</span>
+	<button class="badge" aria-label="Security note" aria-expanded={expanded} onclick={toggle}>ℹ️</button>
+	{#if expanded}
+		<span class="msg msg-info">Note: {info}</span>
+	{/if}
 {/if}
+
+<style>
+	button.badge {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: help;
+		font: inherit;
+		vertical-align: baseline;
+	}
+	span.msg {
+		display: block;
+		white-space: normal;
+		font-size: 0.7rem;
+		max-width: 24rem;
+		margin-top: 0.125rem;
+	}
+	.msg-danger { color: var(--color-pqs-scarlet); }
+	.msg-warning { color: var(--color-pqs-tangerine); }
+	.msg-muted { color: var(--color-pqs-steel); opacity: 0.7; }
+	.msg-info { color: var(--color-pqs-bluegray); }
+</style>


### PR DESCRIPTION
SecurityBadge icons now use a toggle button — tapping reveals the security message inline, accessible on mobile. SchemeTable gains a legend row explaining each icon and the wavy-underline convention. Timing estimate spans keep title for desktop hover and gain aria-label for screen readers.

Closes #30