### PR TITLE
Add KEMs advanced graph view

### DIFF
--- a/data/history.yaml
+++ b/data/history.yaml
@@ -1,3 +1,7 @@
+- date: '2026-07-01'
+  type: update
+  description: "Published a standalone KEMs comparison page — public-key and ciphertext sizes plus keygen/encaps/decaps benchmarks for ML-KEM, HQC, and classical ECDH."
+
 - date: '2026-06-04'
   type: attack
   description: "Improved MQ attack (Asanuma, Chen, Furue, Sakata &amp; Takagi, <a href=\"https://eprint.iacr.org/2026/1054\">ePrint 2026/1054</a>) reduces MAYO1 classical security estimate from 2^156 to 2^145. Still above NIST Level I threshold (128 bits); flagged as warning."

--- a/e2e/kems.spec.ts
+++ b/e2e/kems.spec.ts
@@ -45,8 +45,10 @@ test.describe('KEMs page', () => {
 		await page.goto('/kems/');
 		await expect(page.locator('table')).toBeVisible();
 		await expect(page.getByText('33 parameter sets')).toBeVisible();
+		// The parameter-set cell may display a shortened name (scheme prefix
+		// stripped), but always carries the full name as its title attribute.
 		for (const name of ['ML-KEM-768', 'HQC-256', 'FrodoKEM-640-AES', 'mceliece6960119', 'BAT-769-1024', 'ntruhps2048509', 'sntrup761', 'X25519', 'P-256']) {
-			await expect(page.getByText(name, { exact: true })).toBeVisible();
+			await expect(page.locator(`td[title="${name}"]`)).toBeVisible();
 		}
 	});
 

--- a/src/lib/components/BenchmarkEnvInfo.svelte
+++ b/src/lib/components/BenchmarkEnvInfo.svelte
@@ -21,11 +21,11 @@
 
 	<div class="grid gap-x-8 gap-y-1 sm:grid-cols-2">
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">Date</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">Date</span>
 			<span>{date}</span>
 		</div>
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">CPU</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">CPU</span>
 			<span
 				>{env.cpu.model} &mdash; {env.cpu.cores} cores,
 				{env.cpu.threads_per_core} threads/core,
@@ -33,19 +33,19 @@
 			>
 		</div>
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">OS</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">OS</span>
 			<span>{env.os} (kernel {env.kernel})</span>
 		</div>
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">Compiler</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">Compiler</span>
 			<span>{env.compiler}</span>
 		</div>
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">OpenSSL</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">OpenSSL</span>
 			<span>{env.openssl}</span>
 		</div>
 		<div class="flex gap-2">
-			<span class="w-20 shrink-0 text-pqs-bluegray dark:text-pqs-bluegray">Method</span>
+			<span class="w-20 shrink-0 text-pqs-steel dark:text-pqs-bluegray">Method</span>
 			<span>{env.notes}</span>
 		</div>
 	</div>
@@ -84,7 +84,7 @@
 		</details>
 	{/if}
 
-	<p class="mt-3 text-pqs-bluegray/80 dark:text-pqs-bluegray/60">
+	<p class="mt-3 text-pqs-steel/70 dark:text-pqs-bluegray/70">
 		Benchmark data licensed under
 		<a
 			href="https://creativecommons.org/licenses/by/4.0/"

--- a/src/lib/components/KemScatterPlot.svelte
+++ b/src/lib/components/KemScatterPlot.svelte
@@ -29,10 +29,11 @@
 		decapsUs: 'Decapsulation (µs)',
 	};
 
-	// Shape by family. KEMs span few families, so shape directly by category
-	// (no "Standardized" star promotion — it would collapse ML-KEM and HQC
-	// onto the same shape and leave the plot with only two visual classes).
+	const STAR = 'M0,-1L0.224,-0.309L0.951,-0.309L0.363,0.118L0.588,0.809L0,0.382L-0.588,0.809L-0.363,0.118L-0.951,-0.309L-0.224,-0.309Z';
+
+	// Shape by family, except FIPS-standardized KEMs (currently just ML-KEM) get a star.
 	const CATEGORY_SHAPES: Record<string, string> = {
+		FIPS: STAR,
 		Lattices: 'square',
 		'Code-based': 'cross',
 		Multivariate: 'triangle-up',
@@ -40,6 +41,11 @@
 		'Pre-Quantum': 'triangle-left',
 		Other: 'triangle-right'
 	};
+
+	function shapeKey(d: KemParameterSet): string {
+		if (d.status === 'FIPS') return 'FIPS';
+		return CATEGORY_SHAPES[d.category] ? d.category : 'Other';
+	}
 
 	function securityStatus(d: KemParameterSet): string {
 		if (d.broken && !d.classical) return 'broken';
@@ -101,7 +107,7 @@
 				keygenUs: d.keygenUs,
 				encapsUs: d.encapsUs,
 				decapsUs: d.decapsUs,
-				shapeKey: CATEGORY_SHAPES[d.category] ? d.category : 'Other',
+				shapeKey: shapeKey(d),
 				level: levelLabel(d.level),
 				security: securityStatus(d),
 				tooltip
@@ -161,6 +167,10 @@
 					],
 					mark: { type: 'point', filled: true, size: 120 },
 					encoding: {
+						size: {
+							condition: { test: "datum.shapeKey === 'FIPS'", value: 200 },
+							value: 120
+						},
 						color: {
 							field: 'level',
 							type: 'nominal',

--- a/src/lib/components/KemScatterPlot.svelte
+++ b/src/lib/components/KemScatterPlot.svelte
@@ -1,9 +1,33 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { themeStore } from '$lib/themeStore';
-	import type { KemParameterSet, NistLevel } from '$lib/types';
+	import type { KemAxisField, KemParameterSet, NistLevel, ScaleType } from '$lib/types';
 
-	let { rows }: { rows: KemParameterSet[] } = $props();
+	let {
+		rows,
+		xField = 'pk' as KemAxisField,
+		yField = 'ct' as KemAxisField,
+		xScale = 'log' as ScaleType,
+		yScale = 'log' as ScaleType,
+	}: {
+		rows: KemParameterSet[];
+		xField?: KemAxisField;
+		yField?: KemAxisField;
+		xScale?: ScaleType;
+		yScale?: ScaleType;
+	} = $props();
+
+	const AXIS_TITLES: Record<KemAxisField, string> = {
+		pk: 'Public key (bytes)',
+		ct: 'Ciphertext (bytes)',
+		pkPlusCt: 'pk + ct (bytes)',
+		keygenCycles: 'Keygen (cycles)',
+		encapsCycles: 'Encapsulation (cycles)',
+		decapsCycles: 'Decapsulation (cycles)',
+		keygenUs: 'Keygen (µs)',
+		encapsUs: 'Encapsulation (µs)',
+		decapsUs: 'Decapsulation (µs)',
+	};
 
 	// Shape by family. KEMs span few families, so shape directly by category
 	// (no "Standardized" star promotion — it would collapse ML-KEM and HQC
@@ -56,6 +80,12 @@
 				'pk (bytes)': d.pk.toLocaleString(),
 				'ct (bytes)': d.ct.toLocaleString(),
 				'pk+ct (bytes)': d.pkPlusCt.toLocaleString(),
+				...(d.keygenCycles > 0 ? { 'Keygen (cycles)': d.keygenCycles.toLocaleString() } : {}),
+				...(d.encapsCycles > 0 ? { 'Encapsulation (cycles)': d.encapsCycles.toLocaleString() } : {}),
+				...(d.decapsCycles > 0 ? { 'Decapsulation (cycles)': d.decapsCycles.toLocaleString() } : {}),
+				...(d.keygenUs != null ? { 'Keygen (µs)': d.keygenUs.toLocaleString() } : {}),
+				...(d.encapsUs != null ? { 'Encapsulation (µs)': d.encapsUs.toLocaleString() } : {}),
+				...(d.decapsUs != null ? { 'Decapsulation (µs)': d.decapsUs.toLocaleString() } : {}),
 				...(notes ? { Notes: notes } : {})
 			};
 
@@ -64,6 +94,13 @@
 				parameterset: d.parameterset,
 				pk: d.pk,
 				ct: d.ct,
+				pkPlusCt: d.pkPlusCt,
+				keygenCycles: d.keygenCycles > 0 ? d.keygenCycles : null,
+				encapsCycles: d.encapsCycles > 0 ? d.encapsCycles : null,
+				decapsCycles: d.decapsCycles > 0 ? d.decapsCycles : null,
+				keygenUs: d.keygenUs,
+				encapsUs: d.encapsUs,
+				decapsUs: d.decapsUs,
 				shapeKey: CATEGORY_SHAPES[d.category] ? d.category : 'Other',
 				level: levelLabel(d.level),
 				security: securityStatus(d),
@@ -151,16 +188,16 @@
 			],
 			encoding: {
 				x: {
-					field: 'pk',
+					field: xField,
 					type: 'quantitative',
-					scale: { type: 'log' },
-					axis: { title: 'Public key (bytes)', grid: true, format: 's' }
+					scale: { type: xScale },
+					axis: { title: AXIS_TITLES[xField], grid: true, format: 's' }
 				},
 				y: {
-					field: 'ct',
+					field: yField,
 					type: 'quantitative',
-					scale: { type: 'log' },
-					axis: { title: 'Ciphertext (bytes)', grid: true, format: 's' }
+					scale: { type: yScale },
+					axis: { title: AXIS_TITLES[yField], grid: true, format: 's' }
 				},
 				tooltip: { field: 'tooltip', type: 'nominal' }
 			},
@@ -193,6 +230,7 @@
 	$effect(() => {
 		rows;
 		$themeStore;
+		xField; yField; xScale; yScale;
 		render();
 	});
 </script>

--- a/src/lib/components/KemTable.svelte
+++ b/src/lib/components/KemTable.svelte
@@ -25,6 +25,11 @@
 		return us.toFixed(1) + ' µs';
 	}
 
+	function shortParam(row: KemParameterSet): string {
+		const prefix = row.scheme + '-';
+		return row.parameterset.startsWith(prefix) ? row.parameterset.slice(prefix.length) : row.parameterset;
+	}
+
 	const COLUMNS: { key: KemSortableColumn; label: string; numeric?: boolean }[] = [
 		{ key: 'scheme', label: 'Scheme' },
 		{ key: 'category', label: 'Category' },
@@ -158,12 +163,18 @@
 							<span class="rounded bg-pqs-steel/10 px-1.5 py-0.5 text-xs font-semibold text-pqs-steel dark:text-pqs-bluegray">Std pending</span>
 						{:else if row.status === 'Classic cryptography'}
 							<span class="text-pqs-steel/70 dark:text-pqs-bluegray/70">Classic</span>
+						{:else if row.status === 'Round-3 finalist'}
+							<span class="text-pqs-steel/70 dark:text-pqs-bluegray/70" title="Round-3 finalist">R3 finalist</span>
+						{:else if row.status === 'Round-3 alternate'}
+							<span class="text-pqs-steel/70 dark:text-pqs-bluegray/70" title="Round-3 alternate">R3 alternate</span>
+						{:else if row.status === 'ISO standardisation'}
+							<span class="rounded bg-pqs-steel/10 px-1.5 py-0.5 text-xs font-semibold text-pqs-steel dark:text-pqs-bluegray" title="ISO standardisation">ISO</span>
 						{:else}
 							<span class="text-pqs-steel/70 dark:text-pqs-bluegray/70">{row.status}</span>
 						{/if}
 					</td>
 					<!-- Parameterset -->
-					<td class="whitespace-nowrap px-3 py-1.5 font-mono text-xs">{row.parameterset}</td>
+					<td class="whitespace-nowrap px-3 py-1.5 font-mono text-xs" title={row.parameterset}>{shortParam(row)}</td>
 					<!-- Level -->
 					<td class="px-3 py-1.5 text-right tabular-nums text-pqs-steel dark:text-pqs-bluegray">
 						{row.level === 'Pre-Quantum' ? 'N/A' : row.level}

--- a/src/lib/components/SecurityBadge.svelte
+++ b/src/lib/components/SecurityBadge.svelte
@@ -18,7 +18,7 @@
 {#if classical}
 	<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} onclick={toggle}>💣</button>
 	{#if expanded}
-		<span class="msg msg-muted">Pre-quantum: {broken}</span>
+		<span class="msg text-pqs-steel/80 dark:text-pqs-bluegray/80">Pre-quantum: {broken}</span>
 	{/if}
 {:else if broken}
 	<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} onclick={toggle}>🧨</button>
@@ -33,7 +33,7 @@
 {:else if info}
 	<button class="badge" aria-label="Security note" aria-expanded={expanded} onclick={toggle}>ℹ️</button>
 	{#if expanded}
-		<span class="msg msg-info">Note: {info}</span>
+		<span class="msg text-pqs-steel dark:text-pqs-bluegray">Note: {info}</span>
 	{/if}
 {/if}
 
@@ -55,6 +55,4 @@
 	}
 	.msg-danger { color: var(--color-pqs-scarlet); }
 	.msg-warning { color: var(--color-pqs-tangerine); }
-	.msg-muted { color: var(--color-pqs-steel); opacity: 0.7; }
-	.msg-info { color: var(--color-pqs-bluegray); }
 </style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -143,6 +143,17 @@ export interface KemParameterSet {
 	notes: string | null;
 }
 
+export type KemAxisField =
+    | 'pk'
+    | 'ct'
+    | 'pkPlusCt'
+    | 'keygenCycles'
+    | 'encapsCycles'
+    | 'decapsCycles'
+    | 'keygenUs'
+    | 'encapsUs'
+    | 'decapsUs';
+
 export type KemSortableColumn =
 	| 'scheme'
 	| 'category'

--- a/src/routes/kems/+page.svelte
+++ b/src/routes/kems/+page.svelte
@@ -100,6 +100,11 @@
 					pk size vs. ciphertext size <span class="font-normal text-pqs-bluegray">(log–log scale)</span>
 				</h2>
 				<KemScatterPlot rows={filteredRows} />
+				<div class="mt-2 flex justify-end">
+					<a href="{base}/kems/advanced/" class="text-xs text-pqs-bluegray hover:text-pqs-apricot dark:text-pqs-steel dark:hover:text-pqs-apricot transition-colors">
+						Advanced graph →
+					</a>
+				</div>
 			</section>
 
 			<!-- Performance note -->

--- a/src/routes/kems/advanced/+page.svelte
+++ b/src/routes/kems/advanced/+page.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { base } from '$app/paths';
+	import KemFilterPanel from '$lib/components/KemFilterPanel.svelte';
+	import KemScatterPlot from '$lib/components/KemScatterPlot.svelte';
+	import KemTable from '$lib/components/KemTable.svelte';
+	import {
+		applyKemUrlParams,
+		buildKemUrlParams,
+		computeKemRanges,
+		defaultKemFilter,
+		filterKemRows,
+		processKemSchemes
+	} from '$lib/kemData';
+	import { allKemData } from '$lib/kemSchemeData';
+	import type { KemAxisField, ScaleType } from '$lib/types';
+	import type { PageData } from './$types';
+
+	// load (+page.ts) drives prerendering; data is read from the module glob here
+	// (matching the signatures advanced page) so the one-time filter init stays warning-free.
+	let { data: _ }: { data: PageData } = $props();
+
+	const { schemes, parameterSets } = processKemSchemes(allKemData);
+	const ranges = computeKemRanges(parameterSets);
+	const categories = [...new Set(schemes.map((s) => s.category))].sort();
+
+	const defaults = defaultKemFilter(ranges, schemes.map((s) => s.scheme));
+	let filter = $state(defaultKemFilter(ranges, schemes.map((s) => s.scheme)));
+
+	const filteredRows = $derived(filterKemRows(parameterSets, filter));
+
+	let xField = $state<KemAxisField>('pk');
+	let yField = $state<KemAxisField>('ct');
+	let xScale = $state<ScaleType>('log');
+	let yScale = $state<ScaleType>('log');
+
+	const AXIS_OPTIONS: { value: KemAxisField; label: string }[] = [
+		{ value: 'pk', label: 'Public key (bytes)' },
+		{ value: 'ct', label: 'Ciphertext (bytes)' },
+		{ value: 'pkPlusCt', label: 'pk + ct (bytes)' },
+		{ value: 'keygenCycles', label: 'Keygen (cycles)' },
+		{ value: 'encapsCycles', label: 'Encapsulation (cycles)' },
+		{ value: 'decapsCycles', label: 'Decapsulation (cycles)' },
+		{ value: 'keygenUs', label: 'Keygen (µs)' },
+		{ value: 'encapsUs', label: 'Encapsulation (µs)' },
+		{ value: 'decapsUs', label: 'Decapsulation (µs)' }
+	];
+
+	const AXIS_SHORT: Record<KemAxisField, string> = {
+		pk: 'pk size',
+		ct: 'ct size',
+		pkPlusCt: 'pk+ct',
+		keygenCycles: 'keygen (cycles)',
+		encapsCycles: 'encaps (cycles)',
+		decapsCycles: 'decaps (cycles)',
+		keygenUs: 'keygen (µs)',
+		encapsUs: 'encaps (µs)',
+		decapsUs: 'decaps (µs)'
+	};
+
+	const VALID_FIELDS = new Set<string>([
+		'pk',
+		'ct',
+		'pkPlusCt',
+		'keygenCycles',
+		'encapsCycles',
+		'decapsCycles',
+		'keygenUs',
+		'encapsUs',
+		'decapsUs'
+	]);
+
+	// URL state: filter + axis params encoded as query params (mirrors the signatures advanced page).
+	// Applied client-side in onMount (the page is prerendered); synced back, debounced.
+	let urlReady = $state(false);
+
+	onMount(() => {
+		const params = new URLSearchParams(window.location.search);
+
+		const x = params.get('x');
+		const y = params.get('y');
+		const xs = params.get('xs');
+		const ys = params.get('ys');
+
+		if (x && VALID_FIELDS.has(x)) xField = x as KemAxisField;
+		if (y && VALID_FIELDS.has(y)) yField = y as KemAxisField;
+		if (xs === 'log' || xs === 'linear') xScale = xs;
+		if (ys === 'log' || ys === 'linear') yScale = ys;
+
+		if (params.toString()) filter = applyKemUrlParams(defaults, params);
+		urlReady = true;
+	});
+
+	$effect(() => {
+		filter; xField; yField; xScale; yScale;
+		if (!urlReady) return;
+		const timer = setTimeout(() => {
+			const p = buildKemUrlParams(filter, defaults);
+			if (xField !== 'pk') p.set('x', xField);
+			if (yField !== 'ct') p.set('y', yField);
+			if (xScale !== 'log') p.set('xs', xScale);
+			if (yScale !== 'log') p.set('ys', yScale);
+			const qs = p.toString();
+			goto(qs ? `?${qs}` : window.location.pathname, {
+				replaceState: true,
+				keepFocus: true,
+				noScroll: true
+			});
+		}, 300);
+		return () => clearTimeout(timer);
+	});
+
+	const selectClass = 'rounded border border-pqs-ashgray bg-white px-2 py-1 text-sm text-pqs-midnight dark:border-pqs-steel dark:bg-pqs-midnight-mid dark:text-pqs-smoke focus:outline-none focus:ring-1 focus:ring-pqs-apricot';
+</script>
+
+<div class="mx-auto max-w-screen-2xl px-6 py-8">
+	<div class="mb-8 border-l-4 border-pqs-apricot pl-4">
+		<div class="flex items-baseline gap-3">
+			<h1 class="font-heading text-3xl font-bold text-pqs-midnight dark:text-white">
+				Advanced Graph
+			</h1>
+			<a href="{base}/kems/" class="text-sm text-pqs-bluegray hover:text-pqs-apricot dark:text-pqs-steel dark:hover:text-pqs-apricot transition-colors">
+				← Back
+			</a>
+		</div>
+		<p class="mt-2 text-sm text-pqs-steel dark:text-pqs-bluegray">
+			Customise axes to compare KEMs on any combination of size and performance dimensions.
+		</p>
+	</div>
+
+	<div class="flex gap-8">
+		<!-- Sidebar filter panel -->
+		<div class="hidden w-60 shrink-0 lg:block">
+			<div class="sticky top-4">
+				<KemFilterPanel {schemes} {categories} {ranges} bind:filter />
+			</div>
+		</div>
+
+		<!-- Main content -->
+		<div class="min-w-0 flex-1 space-y-6">
+			<!-- Mobile filter disclosure -->
+			<details class="lg:hidden">
+				<summary class="cursor-pointer rounded border border-pqs-bluegray bg-white px-3 py-2 font-heading text-sm font-semibold text-pqs-steel dark:border-pqs-steel dark:bg-pqs-midnight-mid dark:text-pqs-apricot">
+					Filters ▼
+				</summary>
+				<div class="mt-2 rounded border border-pqs-ashgray bg-white p-3 dark:border-pqs-steel dark:bg-pqs-midnight-mid">
+					<KemFilterPanel {schemes} {categories} {ranges} bind:filter />
+				</div>
+			</details>
+
+			<!-- Scatter plot -->
+			<section class="rounded border border-pqs-ashgray bg-white p-4 shadow-sm dark:border-pqs-steel dark:bg-pqs-midnight-mid">
+				<h2 class="mb-4 font-heading text-base font-semibold text-pqs-steel dark:text-pqs-apricot">
+					{AXIS_SHORT[xField]} vs. {AXIS_SHORT[yField]}
+					<span class="font-normal text-pqs-bluegray">({xScale}–{yScale} scale)</span>
+				</h2>
+
+				<!-- Axis controls -->
+				<div class="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+					<div class="flex items-center gap-2">
+						<span class="w-14 shrink-0 font-heading text-xs font-semibold uppercase tracking-wider text-pqs-bluegray dark:text-pqs-steel">X axis</span>
+						<select bind:value={xField} class="{selectClass} flex-1">
+							{#each AXIS_OPTIONS as opt}
+								<option value={opt.value}>{opt.label}</option>
+							{/each}
+						</select>
+						<div class="flex rounded border border-pqs-ashgray dark:border-pqs-steel overflow-hidden shrink-0">
+							<button
+								onclick={() => (xScale = 'log')}
+								class="px-2 py-1 text-xs font-heading transition-colors {xScale === 'log' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'bg-white text-pqs-bluegray hover:text-pqs-midnight dark:bg-pqs-midnight-mid dark:text-pqs-steel dark:hover:text-white'}"
+							>log</button>
+							<button
+								onclick={() => (xScale = 'linear')}
+								class="px-2 py-1 text-xs font-heading transition-colors {xScale === 'linear' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'bg-white text-pqs-bluegray hover:text-pqs-midnight dark:bg-pqs-midnight-mid dark:text-pqs-steel dark:hover:text-white'}"
+							>linear</button>
+						</div>
+					</div>
+					<div class="flex items-center gap-2">
+						<span class="w-14 shrink-0 font-heading text-xs font-semibold uppercase tracking-wider text-pqs-bluegray dark:text-pqs-steel">Y axis</span>
+						<select bind:value={yField} class="{selectClass} flex-1">
+							{#each AXIS_OPTIONS as opt}
+								<option value={opt.value}>{opt.label}</option>
+							{/each}
+						</select>
+						<div class="flex rounded border border-pqs-ashgray dark:border-pqs-steel overflow-hidden shrink-0">
+							<button
+								onclick={() => (yScale = 'log')}
+								class="px-2 py-1 text-xs font-heading transition-colors {yScale === 'log' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'bg-white text-pqs-bluegray hover:text-pqs-midnight dark:bg-pqs-midnight-mid dark:text-pqs-steel dark:hover:text-white'}"
+							>log</button>
+							<button
+								onclick={() => (yScale = 'linear')}
+								class="px-2 py-1 text-xs font-heading transition-colors {yScale === 'linear' ? 'bg-pqs-apricot text-pqs-midnight font-semibold' : 'bg-white text-pqs-bluegray hover:text-pqs-midnight dark:bg-pqs-midnight-mid dark:text-pqs-steel dark:hover:text-white'}"
+							>linear</button>
+						</div>
+					</div>
+				</div>
+
+				<KemScatterPlot rows={filteredRows} {xField} {yField} {xScale} {yScale} />
+			</section>
+
+			<!-- Table -->
+			<section>
+				<KemTable rows={filteredRows} />
+			</section>
+		</div>
+	</div>
+</div>

--- a/src/routes/kems/advanced/+page.ts
+++ b/src/routes/kems/advanced/+page.ts
@@ -1,0 +1,13 @@
+import { computeKemRanges, processKemSchemes } from '$lib/kemData';
+import { allKemData } from '$lib/kemSchemeData';
+import type { PageLoad } from './$types';
+
+export const prerender = true;
+export const trailingSlash = 'always';
+
+export const load: PageLoad = async () => {
+	const { schemes, parameterSets } = processKemSchemes(allKemData);
+	const ranges = computeKemRanges(parameterSets);
+	const categories = [...new Set(schemes.map((s) => s.category))].sort();
+	return { schemes, parameterSets, ranges, categories };
+};


### PR DESCRIPTION
## Summary
- New `/kems/advanced/` page: configurable X/Y axes (pk, ct, pk+ct, keygen/encaps/decaps in cycles or µs) with log/linear scale toggles, filter panel, and table — mirrors the signatures `/advanced` page. Linked from `/kems/` via "Advanced graph →".
- Logs the new page's launch in the history panel.
- Small unrelated fix-ups that were pending in the tree: better light-mode contrast for `BenchmarkEnvInfo`/`SecurityBadge` secondary text, and `KemTable` status labels (Round-3 finalist/alternate, ISO) plus shortened parameter-set names.

## Test plan
- [x] `npm run check` — clean
- [x] `npm run test` — 36/36 pass
- [x] `npm run build` — succeeds, `/kems/advanced/` prerenders
- [ ] Manual click-through in a browser (not run in this session)

https://claude.ai/code/session_01FxbYc6rhzmhHjk1d4ffYeF