### PR TITLE
Fix component review findings: bugs, a11y, and duplication

### DIFF
--- a/src/lib/components/BenchmarkEnvInfo.svelte
+++ b/src/lib/components/BenchmarkEnvInfo.svelte
@@ -59,10 +59,9 @@
 			</summary>
 			<ul class="mt-2 space-y-0.5 font-mono">
 				{#each Object.entries(env.sources).sort() as [scheme, url]}
-					{@const atIdx = url.lastIndexOf('@')}
-					{@const hasCommit = atIdx > 8}
-					{@const repoUrl = (hasCommit ? url.slice(0, atIdx) : url).replace(/\.git$/, '')}
-					{@const commit = hasCommit ? url.slice(atIdx + 1) : null}
+					{@const m = url.match(/^(.*)@([0-9a-f]{7,40})$/)}
+					{@const repoUrl = (m ? m[1] : url).replace(/\.git$/, '')}
+					{@const commit = m ? m[2] : null}
 					<li class="flex gap-2">
 						<span class="w-16 shrink-0 text-pqs-steel dark:text-pqs-bluegray">{scheme}</span>
 						<a

--- a/src/lib/components/FilterPanel.svelte
+++ b/src/lib/components/FilterPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { DataRanges, FilterState, NistLevel, Scheme } from '$lib/types';
 	import { getFilterStore } from '$lib/filterStore';
+	import { ALL_LEVELS } from '$lib/constants';
 	import RangeField from './RangeField.svelte';
 
 	interface Props {
@@ -17,8 +18,6 @@
 			categories.map((cat) => [cat, schemes.filter((s) => s.category === cat)])
 		)
 	);
-
-	const ALL_LEVELS: NistLevel[] = ['Pre-Quantum', 1, 2, 3, 4, 5];
 
 	function categoryState(cat: string): 'all' | 'some' | 'none' {
 		const catSchemes = schemesByCategory[cat];

--- a/src/lib/components/KemFilterPanel.svelte
+++ b/src/lib/components/KemFilterPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { KemDataRanges, KemFilterState, KemScheme, NistLevel } from '$lib/types';
 	import { defaultKemFilter } from '$lib/kemData';
+	import { ALL_LEVELS } from '$lib/constants';
 	import RangeField from './RangeField.svelte';
 
 	interface Props {
@@ -16,8 +17,6 @@
 	const schemesByCategory = $derived(
 		Object.fromEntries(categories.map((cat) => [cat, schemes.filter((s) => s.category === cat)]))
 	);
-
-	const ALL_LEVELS: NistLevel[] = ['Pre-Quantum', 1, 2, 3, 4, 5];
 
 	function categoryState(cat: string): 'all' | 'some' | 'none' {
 		const catSchemes = schemesByCategory[cat];

--- a/src/lib/components/KemScatterPlot.svelte
+++ b/src/lib/components/KemScatterPlot.svelte
@@ -61,10 +61,28 @@
 	let container = $state<HTMLDivElement | null>(null);
 	let viewHandle: { finalize(): void } | null = null;
 	let renderSeq = 0;
+	let renderQueue: Promise<void> = Promise.resolve();
+	let renderError = $state(false);
+	let innerWidth = $state(0);
+	const isMobile = $derived(innerWidth > 0 && innerWidth < 640);
 
-	async function render() {
-		if (!container) return;
+	// Serialize renders: concurrent vega-embed calls on the same container can
+	// leave a stale, finalized chart in the DOM when they resolve out of order.
+	function render() {
 		const seq = ++renderSeq;
+		renderQueue = renderQueue.then(async () => {
+			try {
+				await doRender(seq);
+				renderError = false;
+			} catch (err) {
+				console.error('scatter plot render failed', err);
+				renderError = true;
+			}
+		});
+	}
+
+	async function doRender(seq: number) {
+		if (!container || seq !== renderSeq) return;
 
 		const { default: embed } = await import('vega-embed');
 		const isDark = document.documentElement.classList.contains('dark');
@@ -131,7 +149,6 @@
 		const categoryDomain = presentShapeKeys;
 		const categoryShapeRange = presentShapeKeys.map((k) => CATEGORY_SHAPES[k]);
 
-		const isMobile = window.innerWidth < 640;
 		const mobileLegend = isMobile
 			? { orient: 'bottom', direction: 'horizontal', columns: 3, labelFontSize: 10 }
 			: {};
@@ -142,11 +159,15 @@
 			padding: 8,
 			...mobileLegend
 		};
-		const shapeLegendConfig = {
-			...legendConfig,
-			symbolFillColor: isDark ? '#94A3B8' : '#475569',
-			symbolStrokeColor: isDark ? '#94A3B8' : '#475569'
-		};
+		// Shape legend is too wide to show on mobile (matches ScatterPlot behaviour;
+		// the "Shape = family" note below the chart compensates).
+		const shapeLegendConfig = isMobile
+			? null
+			: {
+					...legendConfig,
+					symbolFillColor: isDark ? '#94A3B8' : '#475569',
+					symbolStrokeColor: isDark ? '#94A3B8' : '#475569'
+				};
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const spec: any = {
@@ -181,7 +202,7 @@
 							field: 'shapeKey',
 							type: 'nominal',
 							scale: { domain: categoryDomain, range: categoryShapeRange },
-							legend: { title: 'Family', ...shapeLegendConfig }
+							legend: shapeLegendConfig ? { title: 'Family', ...shapeLegendConfig } : null
 						}
 					}
 				},
@@ -225,12 +246,8 @@
 		};
 
 		viewHandle?.finalize();
-		const result = await embed(container, spec, { actions: false, renderer: 'svg' });
-		if (seq !== renderSeq) {
-			result.finalize();
-			return;
-		}
-		viewHandle = result;
+		viewHandle = null;
+		viewHandle = await embed(container, spec, { actions: false, renderer: 'svg' });
 	}
 
 	onMount(() => {
@@ -241,11 +258,17 @@
 		rows;
 		$themeStore;
 		xField; yField; xScale; yScale;
+		isMobile;
 		render();
 	});
 </script>
 
+<svelte:window bind:innerWidth />
+
 <div bind:this={container} class="w-full"></div>
+{#if renderError}
+	<p class="mt-1 text-xs text-pqs-scarlet" role="alert">Chart failed to render.</p>
+{/if}
 <p class="sm:hidden mt-1 text-xs text-pqs-bluegray dark:text-pqs-steel">Shape = family · tap point for details</p>
 <div class="mt-1 flex items-center justify-between">
 	<p class="text-xs text-pqs-bluegray dark:text-pqs-steel">Scroll to zoom · drag to pan</p>

--- a/src/lib/components/KemTable.svelte
+++ b/src/lib/components/KemTable.svelte
@@ -1,29 +1,13 @@
 <script lang="ts">
 	import type { KemParameterSet, KemSortableColumn } from '$lib/types';
+	import { CYCLES_PER_US, CPU_GHZ_LABEL } from '$lib/constants';
+	import { fmt, fmtCycles, fmtTime } from '$lib/format';
 	import SecurityBadge from './SecurityBadge.svelte';
 
 	let { rows }: { rows: KemParameterSet[] } = $props();
 
 	let sortCol = $state<KemSortableColumn>('pkPlusCt');
 	let sortDir = $state<'asc' | 'desc'>('asc');
-
-	function fmt(n: number) {
-		return n.toLocaleString();
-	}
-
-	function fmtCycles(n: number): string {
-		if (n <= 0) return '—';
-		if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'G';
-		if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-		if (n >= 1_000) return (n / 1_000).toFixed(0) + 'K';
-		return String(n);
-	}
-
-	function fmtTime(us: number): string {
-		if (us >= 1_000_000) return (us / 1_000_000).toFixed(2) + ' s';
-		if (us >= 1_000) return (us / 1_000).toFixed(2) + ' ms';
-		return us.toFixed(1) + ' µs';
-	}
 
 	function shortParam(row: KemParameterSet): string {
 		const prefix = row.scheme + '-';
@@ -53,6 +37,13 @@
 		5: 5
 	};
 
+	// Displayed time in µs, or null when the row has no timing data (shown as "—").
+	const TIME_VALUE: Partial<Record<KemSortableColumn, (r: KemParameterSet) => number | null>> = {
+		keygenUs: (r) => r.keygenUs ?? (r.keygenCycles > 0 ? r.keygenCycles / CYCLES_PER_US : null),
+		encapsUs: (r) => r.encapsUs ?? (r.encapsCycles > 0 ? r.encapsCycles / CYCLES_PER_US : null),
+		decapsUs: (r) => r.decapsUs ?? (r.decapsCycles > 0 ? r.decapsCycles / CYCLES_PER_US : null)
+	};
+
 	function compare(a: KemParameterSet, b: KemParameterSet, col: KemSortableColumn): number {
 		switch (col) {
 			case 'level':
@@ -63,12 +54,6 @@
 				return a.ct - b.ct;
 			case 'pkPlusCt':
 				return a.pkPlusCt - b.pkPlusCt;
-			case 'keygenUs':
-				return (a.keygenUs ?? a.keygenCycles / 2500) - (b.keygenUs ?? b.keygenCycles / 2500);
-			case 'encapsUs':
-				return (a.encapsUs ?? a.encapsCycles / 2500) - (b.encapsUs ?? b.encapsCycles / 2500);
-			case 'decapsUs':
-				return (a.decapsUs ?? a.decapsCycles / 2500) - (b.decapsUs ?? b.decapsCycles / 2500);
 			default: {
 				const av = String(a[col] ?? '').toLowerCase();
 				const bv = String(b[col] ?? '').toLowerCase();
@@ -79,6 +64,16 @@
 
 	const sortedRows = $derived(
 		[...rows].sort((a, b) => {
+			// Time columns keep rows without data last regardless of direction.
+			const timeValue = TIME_VALUE[sortCol];
+			if (timeValue) {
+				const av = timeValue(a);
+				const bv = timeValue(b);
+				if (av == null && bv == null) return 0;
+				if (av == null) return 1;
+				if (bv == null) return -1;
+				return sortDir === 'asc' ? av - bv : bv - av;
+			}
 			const cmp = compare(a, b, sortCol);
 			return sortDir === 'asc' ? cmp : -cmp;
 		})
@@ -97,6 +92,11 @@
 		if (sortCol !== col) return '';
 		return sortDir === 'asc' ? ' ▲' : ' ▼';
 	}
+
+	function ariaSort(col: KemSortableColumn): 'ascending' | 'descending' | undefined {
+		if (sortCol !== col) return undefined;
+		return sortDir === 'asc' ? 'ascending' : 'descending';
+	}
 </script>
 
 {#snippet timeCell(us: number | null, cyc: number)}
@@ -106,9 +106,8 @@
 		{:else if cyc > 0}
 			<span
 				class="underline decoration-wavy decoration-pqs-scarlet"
-				title="Estimated from {fmtCycles(cyc)} cycles @ 2.5 GHz"
-				aria-label="{fmtTime(cyc / 2500)} (estimated from {fmtCycles(cyc)} cycles @ 2.5 GHz)"
-			>{fmtTime(cyc / 2500)}</span>
+				title="Estimated from {fmtCycles(cyc)} cycles @ {CPU_GHZ_LABEL}"
+			>{fmtTime(cyc / CYCLES_PER_US)}<span class="sr-only"> (estimated from {fmtCycles(cyc)} cycles @ {CPU_GHZ_LABEL})</span></span>
 		{:else}
 			<span class="text-pqs-bluegray">—</span>
 		{/if}
@@ -120,12 +119,13 @@
 		<thead class="sticky top-0 z-10">
 			<tr class="bg-pqs-steel font-heading text-xs text-white">
 				{#each COLUMNS as col}
-					<th
-						scope="col"
-						class="cursor-pointer select-none whitespace-nowrap px-3 py-2.5 text-left font-semibold hover:bg-pqs-steel-light {col.numeric ? 'text-right' : ''}"
-						onclick={() => setSort(col.key)}
-					>
-						{col.label}{sortIndicator(col.key)}
+					<th scope="col" aria-sort={ariaSort(col.key)} class="whitespace-nowrap p-0">
+						<button
+							onclick={() => setSort(col.key)}
+							class="w-full cursor-pointer select-none px-3 py-2.5 font-semibold hover:bg-pqs-steel-light {col.numeric ? 'text-right' : 'text-left'}"
+						>
+							{col.label}{sortIndicator(col.key)}
+						</button>
 					</th>
 				{/each}
 				<th scope="col" class="px-3 py-2.5 text-left text-xs font-semibold">Assumption</th>

--- a/src/lib/components/RangeField.svelte
+++ b/src/lib/components/RangeField.svelte
@@ -13,7 +13,9 @@
 		type="number"
 		{value}
 		oninput={(e) => {
-			const v = Number((e.target as HTMLInputElement).value);
+			const raw = (e.target as HTMLInputElement).value;
+			if (raw === '') return; // don't treat a cleared field as 0
+			const v = Number(raw);
 			if (!isNaN(v)) onchange(v);
 		}}
 		class="w-full rounded border border-pqs-bluegray bg-pqs-smoke px-2 py-1 text-xs tabular-nums text-pqs-midnight focus:border-pqs-apricot focus:outline-none dark:border-pqs-steel dark:bg-pqs-midnight dark:text-pqs-smoke"

--- a/src/lib/components/ScatterPlot.svelte
+++ b/src/lib/components/ScatterPlot.svelte
@@ -26,6 +26,25 @@
 	let container = $state<HTMLDivElement | null>(null);
 	let viewHandle: { finalize(): void } | null = null;
 	let renderSeq = 0;
+	let renderQueue: Promise<void> = Promise.resolve();
+	let renderError = $state(false);
+	let innerWidth = $state(0);
+	const isMobile = $derived(innerWidth > 0 && innerWidth < 640);
+
+	// Serialize renders: concurrent vega-embed calls on the same container can
+	// leave a stale, finalized chart in the DOM when they resolve out of order.
+	function render() {
+		const seq = ++renderSeq;
+		renderQueue = renderQueue.then(async () => {
+			try {
+				await doRender(seq);
+				renderError = false;
+			} catch (err) {
+				console.error('scatter plot render failed', err);
+				renderError = true;
+			}
+		});
+	}
 
 	const STAR = 'M0,-1L0.224,-0.309L0.951,-0.309L0.363,0.118L0.588,0.809L0,0.382L-0.588,0.809L-0.363,0.118L-0.951,-0.309L-0.224,-0.309Z';
 
@@ -57,9 +76,8 @@
 		return `Level ${level}`;
 	}
 
-	async function render() {
-		if (!container) return;
-		const seq = ++renderSeq;
+	async function doRender(seq: number) {
+		if (!container || seq !== renderSeq) return;
 
 		const { default: embed } = await import('vega-embed');
 		const data = $filteredRows;
@@ -124,7 +142,6 @@
 		const categoryDomain = presentShapeKeys;
 		const categoryShapeRange = presentShapeKeys.map((k) => CATEGORY_SHAPES[k]);
 
-		const isMobile = window.innerWidth < 640;
 		const mobileLegend = isMobile
 			? { orient: 'bottom', direction: 'horizontal', columns: 3, labelFontSize: 10 }
 			: {};
@@ -151,7 +168,7 @@
 			height: 350,
 			autosize: { type: 'fit-x', resize: true },
 			data: { values },
-			resolve: { scale: { x: 'shared', y: 'shared', color: 'independent', shape: 'independent', opacity: 'independent' } },
+			resolve: { scale: { x: 'shared', y: 'shared', color: 'independent', shape: 'independent' } },
 			layer: [
 				{
 					params: [
@@ -228,12 +245,8 @@
 		};
 
 		viewHandle?.finalize();
-		const result = await embed(container, spec, { actions: false, renderer: 'svg' });
-		if (seq !== renderSeq) {
-			result.finalize();
-			return;
-		}
-		viewHandle = result;
+		viewHandle = null;
+		viewHandle = await embed(container, spec, { actions: false, renderer: 'svg' });
 	}
 
 	onMount(() => {
@@ -244,11 +257,17 @@
 		$filteredRows;
 		$themeStore;
 		xField; yField; xScale; yScale;
+		isMobile;
 		render();
 	});
 </script>
 
+<svelte:window bind:innerWidth />
+
 <div bind:this={container} class="w-full"></div>
+{#if renderError}
+	<p class="mt-1 text-xs text-pqs-scarlet" role="alert">Chart failed to render.</p>
+{/if}
 <p class="sm:hidden mt-1 text-xs text-pqs-bluegray dark:text-pqs-steel">Shape = family · tap point for details</p>
 <div class="mt-1 flex items-center justify-between">
 	<p class="text-xs text-pqs-bluegray dark:text-pqs-steel">Scroll to zoom · drag to pan</p>

--- a/src/lib/components/SchemeTable.svelte
+++ b/src/lib/components/SchemeTable.svelte
@@ -1,27 +1,11 @@
 <script lang="ts">
 	import type { SortableColumn } from '$lib/types';
 	import { getFilterStore } from '$lib/filterStore';
+	import { CYCLES_PER_US, CPU_GHZ_LABEL } from '$lib/constants';
+	import { fmt, fmtCycles, fmtTime } from '$lib/format';
 	import SecurityBadge from './SecurityBadge.svelte';
 
 	const { store, filteredRows } = getFilterStore();
-
-	function fmt(n: number) {
-		return n.toLocaleString();
-	}
-
-	function fmtCycles(n: number): string {
-		if (n <= 0) return '—';
-		if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'G';
-		if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-		if (n >= 1_000) return (n / 1_000).toFixed(0) + 'K';
-		return String(n);
-	}
-
-	function fmtTime(us: number): string {
-		if (us >= 1_000_000) return (us / 1_000_000).toFixed(2) + ' s';
-		if (us >= 1_000) return (us / 1_000).toFixed(2) + ' ms';
-		return us.toFixed(1) + ' µs';
-	}
 
 	const COLUMNS: { key: SortableColumn; label: string; numeric?: boolean }[] = [
 		{ key: 'scheme', label: 'Scheme' },
@@ -48,19 +32,40 @@
 		if ($store.sortCol !== col) return '';
 		return $store.sortDir === 'asc' ? ' ▲' : ' ▼';
 	}
+
+	function ariaSort(col: SortableColumn): 'ascending' | 'descending' | undefined {
+		if ($store.sortCol !== col) return undefined;
+		return $store.sortDir === 'asc' ? 'ascending' : 'descending';
+	}
 </script>
+
+{#snippet timeCell(us: number | null, cyc: number)}
+	<td class="px-3 py-1.5 text-right tabular-nums">
+		{#if us != null}
+			{fmtTime(us)}
+		{:else if cyc > 0}
+			<span
+				class="underline decoration-wavy decoration-pqs-scarlet"
+				title="Estimated from {fmtCycles(cyc)} cycles @ {CPU_GHZ_LABEL}"
+			>{fmtTime(cyc / CYCLES_PER_US)}<span class="sr-only"> (estimated from {fmtCycles(cyc)} cycles @ {CPU_GHZ_LABEL})</span></span>
+		{:else}
+			<span class="text-pqs-bluegray">—</span>
+		{/if}
+	</td>
+{/snippet}
 
 <div class="overflow-x-auto rounded border border-pqs-ashgray shadow-sm dark:border-pqs-steel">
 	<table class="min-w-full text-sm">
 		<thead class="sticky top-0 z-10">
 			<tr class="bg-pqs-steel font-heading text-xs text-white">
 				{#each COLUMNS as col}
-					<th
-						scope="col"
-						class="cursor-pointer select-none whitespace-nowrap px-3 py-2.5 text-left font-semibold hover:bg-pqs-steel-light {col.numeric ? 'text-right' : ''}"
-						onclick={() => setSort(col.key)}
-					>
-						{col.label}{sortIndicator(col.key)}
+					<th scope="col" aria-sort={ariaSort(col.key)} class="whitespace-nowrap p-0">
+						<button
+							onclick={() => setSort(col.key)}
+							class="w-full cursor-pointer select-none px-3 py-2.5 font-semibold hover:bg-pqs-steel-light {col.numeric ? 'text-right' : 'text-left'}"
+						>
+							{col.label}{sortIndicator(col.key)}
+						</button>
 					</th>
 				{/each}
 				<th scope="col" class="px-3 py-2.5 text-left text-xs font-semibold">
@@ -116,38 +121,9 @@
 					<td class="px-3 py-1.5 text-right tabular-nums">{fmt(row.sig)}</td>
 					<!-- pk+sig -->
 					<td class="px-3 py-1.5 text-right tabular-nums">{fmt(row.pkPlusSig)}</td>
-					<!-- signing time -->
-					<td class="px-3 py-1.5 text-right tabular-nums">
-						{#if row.signingUs != null}
-							{fmtTime(row.signingUs)}
-						{:else if row.signingCycles > 0}
-							<span
-								class="underline decoration-wavy decoration-pqs-scarlet"
-								title="Estimated from {fmtCycles(row.signingCycles)} cycles @ 2.5 GHz"
-								aria-label="{fmtTime(row.signingCycles / 2500)} (estimated from {fmtCycles(row.signingCycles)} cycles @ 2.5 GHz)"
-							>
-								{fmtTime(row.signingCycles / 2500)}
-							</span>
-						{:else}
-							<span class="text-pqs-bluegray">—</span>
-						{/if}
-					</td>
-					<!-- verification time -->
-					<td class="px-3 py-1.5 text-right tabular-nums">
-						{#if row.verificationUs != null}
-							{fmtTime(row.verificationUs)}
-						{:else if row.verificationCycles > 0}
-							<span
-								class="underline decoration-wavy decoration-pqs-scarlet"
-								title="Estimated from {fmtCycles(row.verificationCycles)} cycles @ 2.5 GHz"
-								aria-label="{fmtTime(row.verificationCycles / 2500)} (estimated from {fmtCycles(row.verificationCycles)} cycles @ 2.5 GHz)"
-							>
-								{fmtTime(row.verificationCycles / 2500)}
-							</span>
-						{:else}
-							<span class="text-pqs-bluegray">—</span>
-						{/if}
-					</td>
+					<!-- signing / verification time -->
+					{@render timeCell(row.signingUs, row.signingCycles)}
+					{@render timeCell(row.verificationUs, row.verificationCycles)}
 					<!-- Assumption -->
 					<td class="px-3 py-1.5 text-pqs-steel/80 dark:text-pqs-bluegray">{row.assumption}</td>
 				</tr>

--- a/src/lib/components/SecurityBadge.svelte
+++ b/src/lib/components/SecurityBadge.svelte
@@ -7,33 +7,32 @@
 	}
 	let { broken, warning, info, classical }: Props = $props();
 	let expanded = $state(false);
+	const msgId = $props.id();
 
-	function toggle(e: MouseEvent | KeyboardEvent) {
-		if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return;
-		e.preventDefault();
+	function toggle() {
 		expanded = !expanded;
 	}
 </script>
 
 {#if classical}
-	<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} onclick={toggle}>💣</button>
+	<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>💣</button>
 	{#if expanded}
-		<span class="msg text-pqs-steel/80 dark:text-pqs-bluegray/80">Pre-quantum: {broken}</span>
+		<span class="msg text-pqs-steel/80 dark:text-pqs-bluegray/80" id={msgId}>Pre-quantum: {broken}</span>
 	{/if}
 {:else if broken}
-	<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} onclick={toggle}>🧨</button>
+	<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>🧨</button>
 	{#if expanded}
-		<span class="msg msg-danger">Broken: {broken}</span>
+		<span class="msg msg-danger" id={msgId}>Broken: {broken}</span>
 	{/if}
 {:else if warning}
-	<button class="badge" aria-label="Security warning" aria-expanded={expanded} onclick={toggle}>⚠️</button>
+	<button class="badge" aria-label="Security warning" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>⚠️</button>
 	{#if expanded}
-		<span class="msg msg-warning">Warning: {warning}</span>
+		<span class="msg msg-warning" id={msgId}>Warning: {warning}</span>
 	{/if}
 {:else if info}
-	<button class="badge" aria-label="Security note" aria-expanded={expanded} onclick={toggle}>ℹ️</button>
+	<button class="badge" aria-label="Security note" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>ℹ️</button>
 	{#if expanded}
-		<span class="msg text-pqs-steel dark:text-pqs-bluegray">Note: {info}</span>
+		<span class="msg text-pqs-steel dark:text-pqs-bluegray" id={msgId}>Note: {info}</span>
 	{/if}
 {/if}
 
@@ -42,7 +41,7 @@
 		background: none;
 		border: none;
 		padding: 0;
-		cursor: help;
+		cursor: pointer;
 		font: inherit;
 		vertical-align: baseline;
 	}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,11 @@
 export const CPUSPEED = 2_500_000_000;
 
+/** Cycles per microsecond at the reference clock (for cycles ↔ µs extrapolation). */
+export const CYCLES_PER_US = CPUSPEED / 1_000_000;
+
+/** Human-readable reference clock, e.g. "2.5 GHz". */
+export const CPU_GHZ_LABEL = `${CPUSPEED / 1_000_000_000} GHz`;
+
 export const NIST_LEVELS = [1, 2, 3, 4, 5] as const;
 
 export const ALL_LEVELS = ['Pre-Quantum', 1, 2, 3, 4, 5] as const;

--- a/src/lib/filterStore.ts
+++ b/src/lib/filterStore.ts
@@ -1,6 +1,7 @@
 import { derived, writable } from 'svelte/store';
 import type { Readable, Writable } from 'svelte/store';
 import type { DataRanges, FilterState, NistLevel, ParameterSet, SortableColumn } from './types';
+import { CYCLES_PER_US } from './constants';
 
 const DEFAULT_SORT_COL: SortableColumn = 'scheme';
 const DEFAULT_SORT_DIR = 'asc' as const;
@@ -106,6 +107,14 @@ export function buildUrlParams(state: FilterState, defaults: FilterState): URLSe
 	return params;
 }
 
+/** Displayed time in µs, or null when the row has no timing data (shown as "—"). */
+function timeValue(row: ParameterSet, col: 'signingUs' | 'verificationUs'): number | null {
+	if (col === 'signingUs') {
+		return row.signingUs ?? (row.signingCycles > 0 ? row.signingCycles / CYCLES_PER_US : null);
+	}
+	return row.verificationUs ?? (row.verificationCycles > 0 ? row.verificationCycles / CYCLES_PER_US : null);
+}
+
 function compareValues(a: ParameterSet, b: ParameterSet, col: SortableColumn): number {
 	const levelOrder: Record<string, number> = {
 		'Pre-Quantum': 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5,
@@ -122,14 +131,26 @@ function compareValues(a: ParameterSet, b: ParameterSet, col: SortableColumn): n
 		case 'pkPlusSig': return a.pkPlusSig - b.pkPlusSig;
 		case 'signingCycles': return a.signingCycles - b.signingCycles;
 		case 'verificationCycles': return a.verificationCycles - b.verificationCycles;
-		case 'signingUs': return (a.signingUs ?? a.signingCycles / 2500) - (b.signingUs ?? b.signingCycles / 2500);
-		case 'verificationUs': return (a.verificationUs ?? a.verificationCycles / 2500) - (b.verificationUs ?? b.verificationCycles / 2500);
 		default: {
 			const av = String(a[col] ?? '').toLowerCase();
 			const bv = String(b[col] ?? '').toLowerCase();
 			return av < bv ? -1 : av > bv ? 1 : 0;
 		}
 	}
+}
+
+/** Sort comparator: time columns keep rows without data last regardless of direction. */
+export function sortRows(a: ParameterSet, b: ParameterSet, col: SortableColumn, dir: 'asc' | 'desc'): number {
+	if (col === 'signingUs' || col === 'verificationUs') {
+		const av = timeValue(a, col);
+		const bv = timeValue(b, col);
+		if (av == null && bv == null) return 0;
+		if (av == null) return 1;
+		if (bv == null) return -1;
+		return dir === 'asc' ? av - bv : bv - av;
+	}
+	const cmp = compareValues(a, b, col);
+	return dir === 'asc' ? cmp : -cmp;
 }
 
 // Stable module-level stores — created once, updated in place on round changes
@@ -184,10 +205,7 @@ export function createFilterStore(
 						return false;
 					return true;
 				})
-				.sort((a, b) => {
-					const cmp = compareValues(a, b, $state.sortCol);
-					return $state.sortDir === 'asc' ? cmp : -cmp;
-				});
+				.sort((a, b) => sortRows(a, b, $state.sortCol, $state.sortDir));
 		});
 	} else {
 		// Round change: reset filter state to new defaults, data already updated via _allRows

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,19 @@
+/** Shared number formatting for the size/performance tables. */
+
+export function fmt(n: number): string {
+	return n.toLocaleString();
+}
+
+export function fmtCycles(n: number): string {
+	if (n <= 0) return '—';
+	if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'G';
+	if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+	if (n >= 1_000) return (n / 1_000).toFixed(0) + 'K';
+	return String(n);
+}
+
+export function fmtTime(us: number): string {
+	if (us >= 1_000_000) return (us / 1_000_000).toFixed(2) + ' s';
+	if (us >= 1_000) return (us / 1_000).toFixed(2) + ' ms';
+	return us.toFixed(1) + ' µs';
+}

--- a/src/lib/kemData.ts
+++ b/src/lib/kemData.ts
@@ -6,9 +6,7 @@ import type {
 	KemSchemeYaml,
 	NistLevel
 } from './types';
-
-/** Extrapolate cycles from µs at the reference clock when only µs is present. */
-const KEM_CPUSPEED = 2_500_000_000;
+import { CPUSPEED } from './constants';
 
 /**
  * Flatten KEM YAML into schemes + parameter-set rows.
@@ -55,7 +53,7 @@ export function processKemSchemes(schemeData: KemSchemeYaml[]): {
 				cycles != null && cycles > 0
 					? cycles
 					: us != null
-						? Math.round((KEM_CPUSPEED * us) / 1_000_000)
+						? Math.round((CPUSPEED * us) / 1_000_000)
 						: 0;
 
 			rows.push({

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
 	const themeLabel = $derived(`Theme: ${$themeStore} — click to cycle`);
 
 	const isHome = $derived($page.route.id === '/');
-	const isKems = $derived($page.route.id === '/kems');
+	const isKems = $derived($page.route.id?.startsWith('/kems') ?? false);
 
 	let menuOpen = $state(false);
 


### PR DESCRIPTION
Fixes 15 findings from a code review of the Svelte components.

## Bugs
- **RangeField**: clearing an input coerced `''` to `0`, zeroing max filters and hiding every row. Cleared fields are now ignored (filter keeps its last valid value).
- **KemTable / filterStore**: rows without timing data compared as 0 µs and sorted as "fastest". They now sort last on time columns regardless of direction.
- **ScatterPlot / KemScatterPlot**: concurrent `vega-embed` renders could resolve out of order, leaving a stale, finalized chart in the DOM. Renders are now serialized through a promise queue with a stale-sequence bail; render failures show an error message instead of an unhandled rejection.
- **Layout**: `isKems` used an exact route match, so `/kems/advanced` showed the "KEMs" nav link instead of "Signatures". Now uses `startsWith`.

## Accessibility
- Sortable table headers are real `<button>`s with `aria-sort` — keyboard operable in both `SchemeTable` and `KemTable`.
- Estimated-time annotation uses visually-hidden (`sr-only`) text instead of an `aria-label` on a non-interactive span.
- `SecurityBadge`: removed dead keyboard handler (native button behaviour covers Enter/Space), linked the expanded message via `aria-controls`, and switched to `cursor: pointer`.

## Consistency / duplication
- Reference clock defined once: `constants.ts` now exports `CYCLES_PER_US` and `CPU_GHZ_LABEL`; `kemData` reuses `CPUSPEED` instead of a private copy. No hardcoded `2500` / "2.5 GHz" left outside constants.
- Shared `fmt` / `fmtCycles` / `fmtTime` moved to `$lib/format.ts`; `SchemeTable` adopts `KemTable`'s `timeCell` snippet.
- Filter panels import `ALL_LEVELS` from constants instead of re-declaring it.
- `KemScatterPlot` hides the shape legend on mobile to match `ScatterPlot`; both plots re-render when crossing the 640px breakpoint (derived boolean, so no per-pixel re-renders).
- Removed leftover `opacity` scale resolution in `ScatterPlot`; `BenchmarkEnvInfo` parses the commit suffix with an explicit hex regex instead of a magic index.

## Testing
- `svelte-check`: 0 errors
- Vitest: 36/36 pass
- Playwright e2e: 33/33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJbB2Y9kfBdakTqT6vrwLZ