### PR TITLE
Add eBACS link to footer

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -212,6 +212,13 @@
 					rel="noopener noreferrer"
 					class="text-pqs-apricot hover:underline">GitHub</a
 				>
+				·
+				<a
+					href="https://bench.cr.yp.to"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="text-pqs-apricot hover:underline">eBACS</a
+				>: more comprehensive benchmarks on more platforms
 			</p>
 		</div>
 	</footer>


### PR DESCRIPTION
## Summary
- Adds link to eBACS (bench.cr.yp.to) in shared footer, next to GitHub link
- Shared layout footer covers both Signatures and KEMs pages

## Test plan
- [ ] Visually check footer on `/` and `/kems/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r2axncs3jeaztFWCqJZ29