### PR TITLE
Add warning notice to SQIsign for improved isogeny problem attack

### DIFF
--- a/data/history.yaml
+++ b/data/history.yaml
@@ -1,3 +1,8 @@
+- date: '2026-07-26'
+  type: attack
+  description: "Improved algorithm for the supersingular isogeny problem (<a href=\"https://eprint.iacr.org/2026/1486\">ePrint 2026/1486</a>) achieves time/memory p^{1/3+o(1)}, down from the previous best p^{1/2}. Relies on an unproven heuristic smoothness assumption and has a superpolynomial overhead plus high memory cost; concrete impact on SQIsign's parameters not yet clarified. Flagged as warning."
+  schemes: [SQIsign]
+
 - date: '2026-07-02'
   type: update
   description: "Added SMAUG-T (finalist algorithm selected in Korea's KpqC competition) to the KEMs comparison page, with benchmarked keygen/encaps/decaps timings for SMAUG-T128, SMAUG-T192, and SMAUG-T256."

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -7,6 +7,7 @@ versions:
   date: '2025-07-07'
   status: On-ramp
   perf_source: submission document
+  warning: "Improved algorithm for the supersingular isogeny problem (ePrint 2026/1486) achieves time/memory p^{1/3+o(1)}, vs. previous best p^{1/2}; relies on an unproven heuristic smoothness assumption and carries a superpolynomial o(1) overhead plus high memory cost — concrete impact on SQIsign's parameters not yet clarified"
   parametersets:
   - name: V
     level: 5
@@ -36,6 +37,7 @@ versions:
   date: '2025-02-05'
   status: On-ramp
   perf_source: submission document
+  warning: "Improved algorithm for the supersingular isogeny problem (ePrint 2026/1486) achieves time/memory p^{1/3+o(1)}, vs. previous best p^{1/2}; relies on an unproven heuristic smoothness assumption and carries a superpolynomial o(1) overhead plus high memory cost — concrete impact on SQIsign's parameters not yet clarified"
   parametersets:
   - name: V
     level: 5


### PR DESCRIPTION
## Summary
- ePrint 2026/1486 gives a p^{1/3+o(1)} algorithm for the supersingular isogeny problem (previous best p^{1/2}) — the hardness assumption SQIsign relies on.
- Relies on an unproven heuristic smoothness assumption, has superpolynomial overhead and high memory cost; authors say concrete impact on parameters is not yet clarified.
- Added `warning` to SQIsign's v2.0.1 (latest) and v2.0 (round-2/3) versions, and a history.yaml entry.

## Test plan
- [x] `npm run test` passes