### PR TITLE
Fix scroll jump when expanding security badge messages

### DIFF
--- a/src/lib/components/SecurityBadge.svelte
+++ b/src/lib/components/SecurityBadge.svelte
@@ -14,29 +14,35 @@
 	}
 </script>
 
-{#if classical}
-	<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>💣</button>
-	{#if expanded}
-		<span class="msg text-pqs-steel/80 dark:text-pqs-bluegray/80" id={msgId}>Pre-quantum: {broken}</span>
+<span class="badge-wrap">
+	{#if classical}
+		<button class="badge" aria-label="Pre-quantum scheme (not quantum-resistant)" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>💣</button>
+		{#if expanded}
+			<span class="msg text-pqs-steel/80 dark:text-pqs-bluegray/80" id={msgId}>Pre-quantum: {broken}</span>
+		{/if}
+	{:else if broken}
+		<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>🧨</button>
+		{#if expanded}
+			<span class="msg msg-danger" id={msgId}>Broken: {broken}</span>
+		{/if}
+	{:else if warning}
+		<button class="badge" aria-label="Security warning" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>⚠️</button>
+		{#if expanded}
+			<span class="msg msg-warning" id={msgId}>Warning: {warning}</span>
+		{/if}
+	{:else if info}
+		<button class="badge" aria-label="Security note" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>ℹ️</button>
+		{#if expanded}
+			<span class="msg text-pqs-steel dark:text-pqs-bluegray" id={msgId}>Note: {info}</span>
+		{/if}
 	{/if}
-{:else if broken}
-	<button class="badge" aria-label="Broken scheme" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>🧨</button>
-	{#if expanded}
-		<span class="msg msg-danger" id={msgId}>Broken: {broken}</span>
-	{/if}
-{:else if warning}
-	<button class="badge" aria-label="Security warning" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>⚠️</button>
-	{#if expanded}
-		<span class="msg msg-warning" id={msgId}>Warning: {warning}</span>
-	{/if}
-{:else if info}
-	<button class="badge" aria-label="Security note" aria-expanded={expanded} aria-controls={expanded ? msgId : undefined} onclick={toggle}>ℹ️</button>
-	{#if expanded}
-		<span class="msg text-pqs-steel dark:text-pqs-bluegray" id={msgId}>Note: {info}</span>
-	{/if}
-{/if}
+</span>
 
 <style>
+	.badge-wrap {
+		position: relative;
+		display: inline-block;
+	}
 	button.badge {
 		background: none;
 		border: none;
@@ -46,11 +52,23 @@
 		vertical-align: baseline;
 	}
 	span.msg {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		z-index: 30;
 		display: block;
 		white-space: normal;
 		font-size: 0.7rem;
-		max-width: 24rem;
-		margin-top: 0.125rem;
+		width: max-content;
+		max-width: min(24rem, 80vw);
+		margin-top: 0.25rem;
+		padding: 0.375rem 0.5rem;
+		border-radius: 0.25rem;
+		background: var(--color-pqs-smoke, #fff);
+		box-shadow: 0 2px 8px rgb(0 0 0 / 0.2);
+	}
+	:global(.dark) span.msg {
+		background: var(--color-pqs-midnight-mid, #1a1a2e);
 	}
 	.msg-danger { color: var(--color-pqs-scarlet); }
 	.msg-warning { color: var(--color-pqs-tangerine); }


### PR DESCRIPTION
## Summary
- Expanding a scheme's security badge (⚠️/🧨/💣/ℹ️) caused a big scroll jump, worse on long text (SQIsign) but present even on short text (UOV).
- Root cause: the message `<span>` was `display: block` inside a `<td>` with no explicit width, so it inherited the *column's* narrow auto-computed width (~90px, sized by the short scheme-name link) instead of its intended `24rem` max-width. Long text wrapped into dozens of lines in that narrow column, ballooning row height (measured 436px for SQIsign, 324px for UOV) and shoving the page down.
- Fix: float the message as an absolutely-positioned popover anchored to the badge button, so it no longer participates in row-height layout — row height now stays constant when toggled, in both light and dark themes.

## Test plan
- [x] `npm run test`
- [x] `npm run check`
- [x] `npm run build` + Playwright script confirming row height is unchanged (53px→53px) before/after toggling SQIsign and UOV badges, was 53px→436px/324px before the fix
- [x] Visual check of popover in light and dark mode