### PR TITLE
Mark HAWK broken: key-recovery attack via second Galois involution

### DIFF
--- a/data/history.yaml
+++ b/data/history.yaml
@@ -1,3 +1,8 @@
+- date: '2026-07-29'
+  type: attack
+  description: "Deterministic key-recovery attack (Straznickas &amp; Weis, Anthropic, <a href=\"https://www-cdn.anthropic.com/e8d50c167ad47beeb03d6109a4a484be95cb38ea/hawk_key_recovery.pdf\">paper</a>) reduces HAWK-n key recovery to poly(n) calls to an exact-SVP oracle in dimension n/2+1, using a second Galois involution (τ: ζ↦−ζ) beyond the complex conjugation prior module-LIP attacks relied on. Lowers key-recovery cost from 2^150 to 2^108 gates (HAWK-512) and from 2^288 to 2^182 gates (HAWK-1024), both below their NIST level thresholds. The smaller HAWK-256 challenge parameter set was fully broken in practice: secret key recovered end-to-end in a few hours on a single 96-core server. Falcon is unaffected. Flagged as broken."
+  schemes: [HAWK]
+
 - date: '2026-07-26'
   type: attack
   description: "Improved algorithm for the supersingular isogeny problem (<a href=\"https://eprint.iacr.org/2026/1486\">ePrint 2026/1486</a>) achieves time/memory p^{1/3+o(1)}, down from the previous best p^{1/2}. Relies on an unproven heuristic smoothness assumption and has a superpolynomial overhead plus high memory cost; concrete impact on SQIsign's parameters not yet clarified. Flagged as warning."

--- a/data/schemes/HAWK.yaml
+++ b/data/schemes/HAWK.yaml
@@ -7,6 +7,7 @@ versions:
   date: '2025-02-05'
   status: On-ramp
   perf_source: submission document
+  broken: "Key-recovery reduces to SVP in dimension n/2+1 via a second Galois involution (Straznickas &amp; Weis, Anthropic, <a href=\"https://www-cdn.anthropic.com/e8d50c167ad47beeb03d6109a4a484be95cb38ea/hawk_key_recovery.pdf\">paper</a>), lowering key-recovery cost below the NIST level threshold for both parameter sets; the smaller HAWK-256 challenge parameter set was fully broken in practice (secret key recovered end-to-end in hours)"
   parametersets:
   - name: '1024'
     level: 5
@@ -16,6 +17,7 @@ versions:
     verification_cycles: 190604
     signing_us: 58.6
     verification_us: 67.0
+    notes: "Attack reduces key-recovery cost from 2^288 to 2^182 gates, below the Level 5 threshold"
   - name: '512'
     level: 1
     pk: 1024
@@ -24,6 +26,7 @@ versions:
     verification_cycles: 90728
     signing_us: 26.8
     verification_us: 31.6
+    notes: "Attack reduces key-recovery cost from 2^150 to 2^108 gates, below the Level 1 threshold (128 bits)"
   tags:
   - round-2
   - round-3  # Round 3 spec not yet available; showing current latest data


### PR DESCRIPTION
## Summary
- New key-recovery attack (Straznickas & Weis, Anthropic) reduces HAWK-n key recovery to poly(n) exact-SVP calls in dimension n/2+1, via the Galois involution τ: ζ↦−ζ in addition to the complex conjugation prior module-LIP attacks used.
- Lowers key-recovery cost from 2^150 → 2^108 gates (HAWK-512) and 2^288 → 2^182 gates (HAWK-1024) — both below their NIST level thresholds, so flagged `broken` (matches repo's MAYO-2 precedent).
- HAWK-256 (challenge parameter set, not in our data) was fully broken in practice: key recovered end-to-end in a few hours on a single 96-core server.
- Falcon is unaffected (no public Hermitian Gram, det B ≠ 1).
- Added history.yaml entry; added per-parameterset notes with the specific gate-count drop.

Source: https://www-cdn.anthropic.com/e8d50c167ad47beeb03d6109a4a484be95cb38ea/hawk_key_recovery.pdf

## Test plan
- [x] `npm run test` — 36 tests pass
- [ ] Visual check of HAWK row security badge on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQZLeVZHg4tLmxYnCmLDYC