### PR TITLE
Add SQIsign 3.0 round-3 spec data

### DIFF
--- a/bench/CLAUDE.md
+++ b/bench/CLAUDE.md
@@ -24,7 +24,7 @@ output to `results/<timestamp>_<cpu>.txt`:
 
 Dependencies: C compiler (cc), make, git submodules initialized.
 - OpenSSL 3.x for classic schemes (detected via `brew --prefix openssl`, `pkg-config`, or `/usr` fallback).
-- CMake ≥ 3.13 + libgmp-dev for SQIsign (`sudo apt-get install cmake libgmp-dev`).
+- CMake ≥ 3.13 for SQIsign (`sudo apt-get install cmake`) — nist-v3 dropped the GMP dependency.
 
 ## Architecture
 
@@ -119,7 +119,7 @@ The shim adapts upstream API conventions to the bench contract. Common issues:
   Use `malloc` for the temporary sm buffer (size = CRYPTO_BYTES + msglen).
 - **Symbol namespacing**: some upstreams (e.g. SQIsign) `#define` all public names to
   namespaced forms via a namespace header. The compiled `.a` will have e.g.
-  `sqisign_lvl1_ref_crypto_sign_keypair` rather than `crypto_sign_keypair`.
+  `sqisign_p324_3_ref_crypto_sign_keypair` rather than `crypto_sign_keypair`.
   Check with `nm lib.a | grep crypto_sign`.  Fix: declare the namespaced symbols as
   `extern` in the shim (using a `@NS_PREFIX@` token from params.tsv) and wrap them
   with plain-name functions.

--- a/bench/README.md
+++ b/bench/README.md
@@ -28,7 +28,7 @@ make
 | Scheme family | Extra requirement |
 |---|---|
 | Classic (RSA, ECDSA, EdDSA) | OpenSSL 3.x (`libssl-dev` / `openssl@3`) |
-| SQIsign | CMake ≥ 3.13 + GMP (`cmake libgmp-dev`) |
+| SQIsign | CMake ≥ 3.13 (`cmake`) |
 | All others | C compiler, make, git |
 
 ## Schemes
@@ -96,7 +96,7 @@ bench/
     ├── uov/          # pqov/pqov
     ├── qruov/        # qruov/round2
     ├── mqom/         # mqom/mqom-v2
-    └── sqisign/      # SQISign/the-sqisign (nist-v2 tag)
+    └── sqisign/      # SQISign/the-sqisign (nist-v3 tag)
 ```
 
 Each scheme directory contains:

--- a/bench/schemes/sqisign/Makefile
+++ b/bench/schemes/sqisign/Makefile
@@ -11,7 +11,10 @@ CSRC   := $(CBUILD)/src
 PARAM_SETS :=
 
 # $(1) = file stem (e.g. sqisign_lvl1)
-# $(2) = level     (e.g. lvl1)
+# $(2) = variant   (e.g. p324_3) — nist-v3 dropped GMP and renamed variants
+#        from lvl1/lvl3/lvl5 to the prime-shape names p324_3/p500_27/p664_17;
+#        the mp and quaternion modules now build one lib per variant too
+#        (no more shared .../ref/generic/... lib).
 define SQISIGN_RULES
 PARAM_SETS += $(1)
 $(BUILD)/$(1).so: $(1)_shim.c $(CSRC)/libsqisign_$(2)_nistapi.a | $(BUILD)
@@ -22,20 +25,20 @@ $(BUILD)/$(1).so: $(1)_shim.c $(CSRC)/libsqisign_$(2)_nistapi.a | $(BUILD)
 	    $(CSRC)/signature/ref/$(2)/libsqisign_signature_$(2).a \
 	    $(CSRC)/verification/ref/$(2)/libsqisign_verification_$(2).a \
 	    $(CSRC)/id2iso/ref/$(2)/libsqisign_id2iso_$(2).a \
-	    $(CSRC)/quaternion/ref/generic/libsqisign_quaternion_generic.a \
+	    $(CSRC)/quaternion/ref/$(2)/libsqisign_quaternion_$(2).a \
 	    $(CSRC)/hd/ref/$(2)/libsqisign_hd_$(2).a \
 	    $(CSRC)/ec/ref/$(2)/libsqisign_ec_$(2).a \
 	    $(CSRC)/gf/ref/$(2)/libsqisign_gf_$(2).a \
-	    $(CSRC)/mp/ref/generic/libsqisign_mp_generic.a \
+	    $(CSRC)/mp/ref/$(2)/libsqisign_mp_$(2).a \
 	    $(CSRC)/precomp/ref/$(2)/libsqisign_precomp_$(2).a \
 	    $(CSRC)/common/generic/libsqisign_common_sys.a \
-	    -lgmp -lm \
+	    -lm \
 	    -o $$@
 endef
 
-$(eval $(call SQISIGN_RULES,sqisign_lvl1,lvl1))
-$(eval $(call SQISIGN_RULES,sqisign_lvl3,lvl3))
-$(eval $(call SQISIGN_RULES,sqisign_lvl5,lvl5))
+$(eval $(call SQISIGN_RULES,sqisign_lvl1,p324_3))
+$(eval $(call SQISIGN_RULES,sqisign_lvl3,p500_27))
+$(eval $(call SQISIGN_RULES,sqisign_lvl5,p664_17))
 
 TARGETS    := $(addprefix $(BUILD)/, $(addsuffix .so, $(PARAM_SETS)))
 SHIM_FILES := $(addsuffix _shim.c, $(PARAM_SETS))
@@ -54,9 +57,9 @@ check-submodule:
 	    exit 1; }
 
 # Build all cmake static libs in one go (cmake configure + make)
-$(CSRC)/libsqisign_lvl1_nistapi.a \
-$(CSRC)/libsqisign_lvl3_nistapi.a \
-$(CSRC)/libsqisign_lvl5_nistapi.a: $(CBUILD)/.built
+$(CSRC)/libsqisign_p324_3_nistapi.a \
+$(CSRC)/libsqisign_p500_27_nistapi.a \
+$(CSRC)/libsqisign_p664_17_nistapi.a: $(CBUILD)/.built
 	@true
 
 $(CBUILD)/.built: $(REF)/CMakeLists.txt | $(CBUILD)

--- a/bench/schemes/sqisign/params.tsv
+++ b/bench/schemes/sqisign/params.tsv
@@ -1,4 +1,4 @@
 file	name	pk	sk	sig	iters	level	ns_prefix
-sqisign_lvl1	SQIsign-I	65	353	148	50	lvl1	sqisign_lvl1_ref
-sqisign_lvl3	SQIsign-III	97	529	224	50	lvl3	sqisign_lvl3_ref
-sqisign_lvl5	SQIsign-V	129	701	292	50	lvl5	sqisign_lvl5_ref
+sqisign_lvl1	SQIsign-I	83	270	200	50	p324_3	sqisign_p324_3_ref
+sqisign_lvl3	SQIsign-III	129	417	306	50	p500_27	sqisign_p500_27_ref
+sqisign_lvl5	SQIsign-V	169	549	406	50	p664_17	sqisign_p664_17_ref

--- a/data/history.yaml
+++ b/data/history.yaml
@@ -1,3 +1,8 @@
+- date: '2026-09-01'
+  type: update
+  description: "SQIsign 3.0 released as the third-round submission spec: parameters revised in response to the improved supersingular isogeny-problem algorithm (ePrint 2026/1486), and the reference implementation drops its GMP dependency for a from-scratch fixed-precision integer library. Public key and signature sizes grow (level I: 65/148 &rarr; 83/200 bytes; level III: 97/224 &rarr; 129/306; level V: 129/292 &rarr; 169/406 bytes), and both signing and verification are considerably faster than v2.0.1."
+  schemes: [SQIsign]
+
 - date: '2026-08-07'
   type: attack
   description: "Passive full-key-recovery attack on MQOM v2 (Delgado, <a href=\"https://eprint.iacr.org/2026/1542\">ePrint 2026/1542</a>): the v2.x spec derives correlated GGM roots from a fresh master seed via a fixed, zero-salt PRG call (Algorithm 10), so repeated seeds across signatures, keys, and salts leak linear equations in the MQ witness. A parity-indexed XOR-collision attack recovers the complete signing key, but requires signature/query volumes at NIST's outer Q=2^64 permitted bound (~39% success in Category I) or substantial precomputation (tens of GiB&ndash;PiB of tables) to push higher; affects Categories I, III, and V, verified against every official tag from v2.0.0 through v2.1.1. Fix: salt-bound, domain-separated root expansion. v1.0 unaffected. Flagged as warning."

--- a/data/schemes/SQIsign.yaml
+++ b/data/schemes/SQIsign.yaml
@@ -3,6 +3,38 @@ website: https://sqisign.org/
 category: Isogenies
 assumption: Isogenies
 versions:
+- version: v3.0
+  date: '2026-09-01'
+  status: On-ramp
+  perf_source: submission document
+  warning: "Third-round parameters revised in direct response to the improved algorithm for the supersingular isogeny problem (ePrint 2026/1486, time/memory p^{1/3+o(1)}); the spec's own concrete-security estimates (~150/222/285 bits for levels I/III/V) exceed NIST's targets (143/207/272) by only 7-14 bits, and the authors note the polylogarithmic cost factors underlying that estimate are sensitive to further algorithmic improvements"
+  tags:
+  - round-3
+  parametersets:
+  - name: V
+    level: 5
+    pk: 169
+    sig: 406
+    signing_cycles: 674700000
+    verification_cycles: 77600000
+    signing_us: 198441.2
+    verification_us: 22823.5
+  - name: III
+    level: 3
+    pk: 129
+    sig: 306
+    signing_cycles: 320300000
+    verification_cycles: 31500000
+    signing_us: 94205.9
+    verification_us: 9264.7
+  - name: I
+    level: 1
+    pk: 83
+    sig: 200
+    signing_cycles: 93900000
+    verification_cycles: 12100000
+    signing_us: 27617.6
+    verification_us: 3558.8
 - version: v2.0.1
   date: '2025-07-07'
   status: On-ramp
@@ -59,7 +91,6 @@ versions:
     verification_cycles: 5100000
   tags:
   - round-2
-  - round-3  # Round 3 spec not yet available; showing current latest data
 - version: v1.0
   date: '2023-06-01'
   status: On-ramp


### PR DESCRIPTION
## Summary
- Add SQIsign 3.0 (round-3 submission, 2026-09-01) as new version entry, tagged `round-3`
- Sizes grow in response to Wesolowski's p^{1/3+o(1)} isogeny-problem attack: I 65/148→83/200, III 97/224→129/306, V 129/292→169/406 bytes (pk/sig); signing/verification get faster despite the increase
- Drop placeholder `round-3` tag from v2.0 entry now that the real round-3 spec exists
- Add history.yaml entry for the release
- Port `bench/schemes/sqisign/` to the nist-v3 submodule tag: nist-v3 renamed build variants (lvl1/lvl3/lvl5 → p324_3/p500_27/p664_17), dropped GMP, and gave `mp`/`quaternion` per-variant libs instead of a shared `generic` one. Fixed Makefile link line + params.tsv sizes; verified with a local build and `./bench sqisign` run.

Data cross-checked against the `nist-v3` GitHub tag KAT vectors (byte lengths) and the official spec PDF (sizes table, performance table), not just the site's summary page. SQIsign.yaml keeps the submission-doc Table 13 cycle counts rather than sandbox-measured ones — this environment isn't the reference hardware behind `data/benchmark_env.yaml`, so `update_scheme_data.py` wasn't run here to avoid overwriting that shared file with non-representative timings. Someone with access to the reference machine can run `./run_bench.sh sqisign` and `update_scheme_data.py` to get real measured numbers in.

## Test plan
- [x] `bench/schemes/sqisign` builds cleanly against nist-v3 and `./bench sqisign` runs (verified locally)
- [x] YAML structure matches existing scheme schema (visually verified, no local npm available in this env)
- [x] `npm run test` / `npm run build` pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)